### PR TITLE
Specify knowledge map value types

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -590,7 +590,12 @@ components:
           description: >-
             Lookup dict that maps QNode and QEdge identifiers in the QueryGraph to
             Node and Edge identifiers in the KnowledgeGraph
-          additionalProperties: true
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
     KnowledgeGraph:
       type: object
       description: >-


### PR DESCRIPTION
e.g. `"n01": "MONDO:0005737"` OR `"n01": ["MONDO:0005737", "MONDO:0007959"]`
Value can be a string or list of strings.