### PR TITLE
Fix for OpenApi code generation

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -283,6 +283,7 @@ components:
         tag:
           type: string
     Query:
+      x-body-name: request_body
       type: object
       properties:
         bypass_cache:
@@ -910,6 +911,7 @@ components:
           description: A URL corresponding to this attribute
       additionalProperties: true
     Feedback:
+      x-body-name: feedback
       type: object
       description: A single unit of Feedback
       properties:


### PR DESCRIPTION
These changes will allow [Connexion](https://github.com/zalando/connexion/issues) to pass the request body into the [generated](https://github.com/OpenAPITools/openapi-generator) controller methods for the two post methods.

Unfortunately OpenAPI Generator is a bit inconsistent in how it chooses parameter names. Having `additionalProperties: true` in `Query` causes it to not use the lowercase name of the object (in this case "query") as the parameter name and instead default to "request_body". Otherwise, when this property isn't set, it seems to choose the lowercase name of the object (as can be seen in the case of `Feedback`, where "feedback" is chosen as the parameter name).