### PR TITLE
/predicates endpoint

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -28,10 +28,10 @@ paths:
           content:
             application/json:
               schema:
-                description: Target map
+                description: Source map
                 type: object
                 additionalProperties:
-                  description: Source map
+                  description: Target map
                   type: object
                   additionalProperties:
                     description: Array of predicates
@@ -39,8 +39,8 @@ paths:
                     items:
                       type: string
                 example:
-                  gene:
-                    chemical_substance:
+                  chemical_substance:
+                    gene:
                       - directly_interacts_with
                       - decreases_activity_of
   /query:

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -19,6 +19,30 @@ tags:
       description: Documentation for the reasoner query function
       url: 'http://reasonerhost.ncats.io/overview.html#query'
 paths:
+  /predicates:
+    get:
+      summary: Get supported relationships by source and target
+      responses:
+        '200':
+          description: Predicates by source and target
+          content:
+            application/json:
+              schema:
+                description: Target map
+                type: object
+                additionalProperties:
+                  description: Source map
+                  type: object
+                  additionalProperties:
+                    description: Array of predicates
+                    type: array
+                    items:
+                      type: string
+                example:
+                  gene:
+                    chemical_substance:
+                      - directly_interacts_with
+                      - decreases_activity_of
   /query:
     post:
       tags:

--- a/API/TranslatorReasonersAPI_optional.yaml
+++ b/API/TranslatorReasonersAPI_optional.yaml
@@ -23,6 +23,30 @@ tags:
       description: Documentation for the reasoner result function
       url: 'http://reasonerhost.ncats.io/overview.html#result'
 paths:
+  /predicates:
+    get:
+      summary: Get supported relationships by source and target
+      responses:
+        '200':
+          description: Predicates by source and target
+          content:
+            application/json:
+              schema:
+                description: Source map
+                type: object
+                additionalProperties:
+                  description: Target map
+                  type: object
+                  additionalProperties:
+                    description: Array of predicates
+                    type: array
+                    items:
+                      type: string
+                example:
+                  chemical_substance:
+                    gene:
+                      - directly_interacts_with
+                      - decreases_activity_of
   /feedback/ratings:
     get:
       tags:


### PR DESCRIPTION
For comparison, here is the alternative proposal:
https://biomedical-translator.slack.com/archives/C92KXC9DL/p1557167017024100

The "array of triples" would be much more flexible, allowing addition of metadata (e.g. number of such edges, other source/target attributes?) without structural changes, and potentially avoiding future issues of the type we've had in other places (https://github.com/NCATS-Tangerine/NCATS-ReasonerStdAPI/issues/56#issuecomment-489767605).