### PR TITLE
Bug fix: object with items

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -74,10 +74,7 @@ components:
       type: object
       properties:
         message:
-          type: object
-          description: Message object that represents the query to be answered
-          items:
-            $ref: '#/components/schemas/Message'
+          $ref: '#/components/schemas/Message'
       additionalProperties: true
     Message:
       type: object


### PR DESCRIPTION
Extract `$ref` from `items`. Remove other keys, including `description`, which was out of date.

> You will always use $ref as the only key in an object: any other keys you put there will be ignored by the validator.

https://json-schema.org/understanding-json-schema/structuring.html