### PR TITLE
typo fix

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -128,7 +128,7 @@ components:
                 type: string
           description: One or more knowledge-graph node ids, i.e. the `id` of a KNode
       required:
-        - qq_id
+        - qg_id
         - kg_id
     EdgeBinding:
       type: object


### PR DESCRIPTION
`qq_id` => `qg_id`

Thanks to @srensi for pointing this out.