### PR TITLE
Test that optional and primary specs are aligned

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ install:
   - pip install tox
 script: 
   - tox
+  - tests/test_superset.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: xenial
 language: python
 python:
   - "3.7"
+before_install:
+  - sudo apt-get install -y diffstat
 install:
   - pip install tox
 script: 

--- a/API/TranslatorReasonersAPI_optional.yaml
+++ b/API/TranslatorReasonersAPI_optional.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.1
 info:
-  description: (Optional) OpenAPI for NCATS Biomedical Translator Reasoners
-  version: 0.9.2dev
-  title: (Optional) OpenAPI for NCATS Biomedical Translator Reasoners
+  description: OpenAPI for NCATS Biomedical Translator Reasoners
+  version: 0.9.1
+  title: OpenAPI for NCATS Biomedical Translator Reasoners
   contact:
     email: edeutsch@systemsbiology.org
   license:

--- a/tests/test_superset.sh
+++ b/tests/test_superset.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-STATS=$(
-    diff API/TranslatorReasonersAPI.yaml API/TranslatorReasonersAPI_optional.yaml \
-    | \
-    diffstat
-)
-if grep -q "deletion" <<< "$STATS"; then
+DIFF=$(diff API/TranslatorReasonersAPI.yaml API/TranslatorReasonersAPI_optional.yaml)
+STATS=$(diffstat <<< "$DIFF")
+if echo "$STATS" | grep -q "deletion"; then
+    >&2 echo 'Some lines from API/TranslatorReasonersAPI.yaml do not exist in API/TranslatorReasonersAPI_optional.yaml:'
+    DELS=$(echo "$DIFF" | grep -E '^<' | sed -E 's/^<//')
+    >&2 echo "$DELS"
     exit 1
 else
     exit 0

--- a/tests/test_superset.sh
+++ b/tests/test_superset.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+STATS=$(
+    diff API/TranslatorReasonersAPI.yaml API/TranslatorReasonersAPI_optional.yaml \
+    | \
+    diffstat
+)
+if grep -q "deletion" <<< "$STATS"; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
This tests that you can strictly add lines to the file API/TranslatorReasonersAPI_optional.yaml to get API/TranslatorReasonersAPI_optional.yaml.

I've ensured that it passes in this branch, but here is an example failing commit:
https://travis-ci.com/NCATS-Gamma/NCATS-ReasonerStdAPI/builds/123258391