### PR TITLE
Convert *graph nodes/edges and *bindings to maps

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -114,14 +114,14 @@ components:
       description: One of potentially several results or answers for a query
       properties:
         node_bindings:
-          type: array
+          type: object
           description: List of QNode-KNode bindings.
-          items:
+          additionalProperties:
             $ref: '#/components/schemas/NodeBinding'
         edge_bindings:
-          type: array
+          type: object
           description: List of QEdge-KEdge bindings.
-          items:
+          additionalProperties:
             $ref: '#/components/schemas/EdgeBinding'
       required:
         - node_bindings
@@ -129,9 +129,6 @@ components:
     NodeBinding:
       type: object
       properties:
-        qg_id:
-          type: string
-          description: Query-graph node id, i.e. the `node_id` of a QNode
         kg_id:
           oneOf:
             - type: string
@@ -140,14 +137,10 @@ components:
                 type: string
           description: One or more knowledge-graph node ids, i.e. the `id` of a KNode
       required:
-        - qg_id
         - kg_id
     EdgeBinding:
       type: object
       properties:
-        qg_id:
-          type: string
-          description: Query-graph edge id, i.e. the `edge_id` of a QEdge
         kg_id:
           oneOf:
             - type: string
@@ -156,7 +149,6 @@ components:
                 type: string
           description: One or more knowledge-graph edge ids, i.e. the `id` of a KEdge
       required:
-        - qg_id
         - kg_id
     KnowledgeGraph:
       type: object

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -117,12 +117,16 @@ components:
           type: object
           description: List of QNode-KNode bindings.
           additionalProperties:
-            $ref: '#/components/schemas/NodeBinding'
+            type: array
+            items:
+              $ref: '#/components/schemas/NodeBinding'
         edge_bindings:
           type: object
           description: List of QEdge-KEdge bindings.
           additionalProperties:
-            $ref: '#/components/schemas/EdgeBinding'
+            type: array
+            items:
+              $ref: '#/components/schemas/EdgeBinding'
       required:
         - node_bindings
         - edge_bindings

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -223,14 +223,14 @@ components:
         answer the question. This graph is a representation of a question.
       properties:
         nodes:
-          type: array
+          type: object
           description: List of nodes in the QueryGraph
-          items:
+          additionalProperties:
             $ref: '#/components/schemas/QNode'
         edges:
-          type: array
+          type: object
           description: List of edges in the QueryGraph
-          items:
+          additionalProperties:
             $ref: '#/components/schemas/QEdge'
       additionalProperties: true
       required:
@@ -240,12 +240,6 @@ components:
       type: object
       description: A node in the QueryGraph
       properties:
-        id:
-          type: string
-          example: n00
-          description: >-
-            QueryGraph internal identifier for this QNode. Recommended form: n00,
-            n01, n02, etc.
         curie:
           oneOf:
             - type: string
@@ -261,18 +255,10 @@ components:
               items:
                 $ref: '#/components/schemas/BiolinkEntity'
       additionalProperties: true
-      required:
-        - id
     QEdge:
       type: object
       description: An edge in the QueryGraph
       properties:
-        id:
-          type: string
-          example: e00
-          description: >-
-            QueryGraph internal identifier for this QEdge. Recommended form: e00,
-            e01, e02, etc.
         type:
           oneOf:
             - $ref: '#/components/schemas/BiolinkRelation'
@@ -289,7 +275,6 @@ components:
           description: Corresponds to the @id of target node of this edge
       additionalProperties: true
       required:
-        - id
         - source_id
         - target_id
     Node:

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -166,14 +166,14 @@ components:
         of the path may be included.
       properties:
         nodes:
-          type: array
+          type: object
           description: List of nodes in the KnowledgeGraph
-          items:
+          additionalProperties:
             $ref: '#/components/schemas/Node'
         edges:
-          type: array
+          type: object
           description: List of edges in the KnowledgeGraph
-          items:
+          additionalProperties:
             $ref: '#/components/schemas/Edge'
       additionalProperties: true
       required:
@@ -296,10 +296,6 @@ components:
       type: object
       description: A node in the thought subgraph
       properties:
-        id:
-          type: string
-          example: 'OMIM:603903'
-          description: CURIE identifier for this node
         name:
           type: string
           example: Haptoglobin
@@ -311,19 +307,10 @@ components:
               items:
                 $ref: '#/components/schemas/BiolinkEntity'
       additionalProperties: true
-      required:
-        - id
     Edge:
       type: object
       description: An edge in the thought subgraph linking two nodes
       properties:
-        id:
-          type: string
-          example: '553903'
-          description: >-
-            Local identifier for this edge which is unique within this
-            KnowledgeGraph, and perhaps within the source reasoner's knowledge
-            graph
         type:
           $ref: '#/components/schemas/BiolinkRelation'
         source_id:
@@ -336,7 +323,6 @@ components:
           description: Corresponds to the @id of target node of this edge
       additionalProperties: true
       required:
-        - id
         - source_id
         - target_id
     BiolinkEntity:

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -134,24 +134,16 @@ components:
       type: object
       properties:
         kg_id:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
-          description: One or more knowledge-graph node ids, i.e. the `id` of a KNode
+          type: string
+          description: A knowledge-graph node id, i.e. the `id` of a KNode
       required:
         - kg_id
     EdgeBinding:
       type: object
       properties:
         kg_id:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
-          description: One or more knowledge-graph edge ids, i.e. the `id` of a KEdge
+          type: string
+          description: A knowledge-graph edge id, i.e. the `id` of a KEdge
       required:
         - kg_id
     KnowledgeGraph:


### PR DESCRIPTION
This is a draft proposal to address #94. It has three parts:
1. Convert `query_graph` `nodes` and `edges` fields from lists to maps. The `id` field of each becomes the associated key.
2. Convert `knowledge_graph` `nodes` and `edges` fields from lists to maps. The `id` field of each becomes the associated key.
3. Convert `node_` and `edge_bindings` from lists to maps. The `qg_id` field of each becomes the associated key. The value is a list of all bindings using that `qg_id` because, unlike with 1 and 2, the `qg_id`s are not expected to be unique (i.e. there may be multiple entities bound to each query element).

These changes come with some benefits:
* This restructuring is often performed by servers/clients anyway, so we can ease the burden on them.
* We can enforce uniqueness of `id`s in both `query_` and `knowledge_graph`s.

I also have some concerns:
* This will require a significant refactoring effort for current implementers.
* [re: 2] In the `knowledge_graph`, `id`s are typically of the form 'XXX:YYY', and are not valid attribute names in Python or JavaScript. This will not prevent the use of these structures, but may limit some options.