### PR TITLE
Add EdgeAttribute only

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -290,17 +290,17 @@ components:
           $ref: '#/components/schemas/BiolinkRelation'
         source_id:
           type: string
-          example: 'OMIM:603903'
+          example: OMIM:603903
           description: Corresponds to the map key CURIE of the source node of this edge
         target_id:
           type: string
-          example: 'UniProtKB:P00738'
+          example: UniProtKB:P00738
           description: Corresponds to the map key CURIE of the target node of this edge
         attributes:
-          type: "array"
-          description: "A list of additional attributes for this edge"
+          type: array
+          description: A list of additional attributes for this edge
           items:
-            $ref: "#/components/Attribute"
+            $ref: '#/components/Attribute'
       additionalProperties: false
       required:
         - source_id

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -296,7 +296,7 @@ components:
           type: string
           example: 'UniProtKB:P00738'
           description: Corresponds to the map key CURIE of the target node of this edge
-        edge_attributes:
+        attributes:
           type: "array"
           description: "A list of additional attributes for this edge"
           items:

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -284,22 +284,54 @@ components:
       additionalProperties: false
     Edge:
       type: object
-      description: An edge in the thought subgraph linking two nodes
+      description: An edge in the knowledge graph linking two nodes
       properties:
         type:
           $ref: '#/components/schemas/BiolinkRelation'
         source_id:
           type: string
-          example: https://omim.org/entry/603903
-          description: Corresponds to the @id of source node of this edge
+          example: 'OMIM:603903'
+          description: Corresponds to the map key CURIE of the source node of this edge
         target_id:
           type: string
-          example: https://www.uniprot.org/uniprot/P00738
-          description: Corresponds to the @id of target node of this edge
-      additionalProperties: true
+          example: 'UniProtKB:P00738'
+          description: Corresponds to the map key CURIE of the target node of this edge
+        edge_attributes:
+          type: "array"
+          description: "A list of additional attributes for this edge"
+          items:
+            $ref: "#/components/EdgeAttribute"
+      additionalProperties: false
       required:
         - source_id
         - target_id
+    EdgeAttribute:
+      type: object
+      description: Generic attribute for an edge
+      properties:
+        name:
+          type: string
+          description: Human-readable name or label for the attribute. Should be the name of the semantic type term.
+          example: PubMed Identifier
+        value:
+          example: 32529952
+          description: Value of the attribute. May be any data type, including a list.
+        type:
+          type: string
+          description: CURIE of the semantic type of the attribute, from the EDAM ontology if possible.
+          example: 'EDAM:data_1187'
+        url:
+          type: string
+          description: Human-consumable URL to link out and read about the attribute (not the Node).
+          example: 'https://pubmed.ncbi.nlm.nih.gov/32529952'
+        source:
+          type: string
+          description: Source of the attribute, as a CURIE prefix.
+          example: UniProtKB
+      required:
+        - type
+        - value
+      additionalProperties: false
     BiolinkEntity:
       description: A subclass of category named_thing (snake_case)
       type: string

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -291,11 +291,13 @@ components:
         source_id:
           type: string
           example: OMIM:603903
-          description: Corresponds to the map key CURIE of the source node of this edge
+          description: >-
+            Corresponds to the map key CURIE of the source node of this edge
         target_id:
           type: string
           example: UniProtKB:P00738
-          description: Corresponds to the map key CURIE of the target node of this edge
+          description: >-
+            Corresponds to the map key CURIE of the target node of this edge
         attributes:
           type: array
           description: A list of additional attributes for this edge

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -255,8 +255,8 @@ components:
         name:
           type: string
           description: >-
-            Human-readable name or label for the NodeAttribute. Should be the
-            name of the semantic type term.
+            Human-readable name or label for the attribute. Should be the name
+            of the semantic type term.
           example: PubMed Identifier
         value:
           example: 32529952
@@ -273,12 +273,12 @@ components:
         url:
           type: string
           description: >-
-            Human-consumable URL to link out and read about the NodeAttribute
-            (not the Node).
+            Human-consumable URL to link out and read about the attribute (not
+            the node).
           example: https://pubmed.ncbi.nlm.nih.gov/32529952
         source:
           type: string
-          description: Source of the NodeAttribute, as a CURIE prefix.
+          description: Source of the attribute, as a CURIE prefix.
           example: UniProtKB
       required:
         - type

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -266,7 +266,9 @@ components:
           type: string
           description: >-
             CURIE of the semantic type of the attribute, from the EDAM ontology
-            if possible.
+            if possible. If a suitable identifier does not exist, enter a
+            descriptive phrase here and submit the new type for consideration
+            by the appropriate authority.
           example: EDAM:data_1187
         url:
           type: string

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -246,9 +246,9 @@ components:
           type: array
           description: A list of attributes describing the node
           items:
-            $ref: '#/components/schemas/NodeAttribute'
+            $ref: '#/components/schemas/Attribute'
       additionalProperties: false
-    NodeAttribute:
+    Attribute:
       type: object
       description: Generic attribute for a node
       properties:
@@ -300,38 +300,11 @@ components:
           type: "array"
           description: "A list of additional attributes for this edge"
           items:
-            $ref: "#/components/EdgeAttribute"
+            $ref: "#/components/Attribute"
       additionalProperties: false
       required:
         - source_id
         - target_id
-    EdgeAttribute:
-      type: object
-      description: Generic attribute for an edge
-      properties:
-        name:
-          type: string
-          description: Human-readable name or label for the attribute. Should be the name of the semantic type term.
-          example: PubMed Identifier
-        value:
-          example: 32529952
-          description: Value of the attribute. May be any data type, including a list.
-        type:
-          type: string
-          description: CURIE of the semantic type of the attribute, from the EDAM ontology if possible.
-          example: 'EDAM:data_1187'
-        url:
-          type: string
-          description: Human-consumable URL to link out and read about the attribute (not the Node).
-          example: 'https://pubmed.ncbi.nlm.nih.gov/32529952'
-        source:
-          type: string
-          description: Source of the attribute, as a CURIE prefix.
-          example: UniProtKB
-      required:
-        - type
-        - value
-      additionalProperties: false
     BiolinkEntity:
       description: A subclass of category named_thing (snake_case)
       type: string


### PR DESCRIPTION
This pull request provides a minimalist addition of only EdgeAttribute (and removes additionalProperties: true) such that all attributes that we want to have on our edges all go in EdgeAttributes. This is alternative to the other pull request with multiple "second-class" attributes. One PR or the other, or somewhere in between?
