### PR TITLE
Added "translator" and "reasoner" tags

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -25,7 +25,7 @@ tags:
       description: Documentation for the reasoner query function
       url: http://reasonerhost.ncats.io/overview.html#query
   - name: translator
-  - name: reasoner 
+  - name: reasoner
 paths:
   /predicates:
     get:

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -23,6 +23,8 @@ tags:
     externalDocs:
       description: Documentation for the reasoner query function
       url: 'http://reasonerhost.ncats.io/overview.html#query'
+  - name: translator
+  - name: reasoner 
 paths:
   /predicates:
     get:


### PR DESCRIPTION
Adding "translator" and "reasoner" tags in this template to indicate an API as a "Translator's KP API implemented as ReasonerStdAPI", when [registered in SmartAPI registry](https://smart-api.info/add_api).

"translator" tag is included for all Translator KP APIs, and "reasoner" tag is specific for Reasoner APIs.