### PR TITLE
Restore components inadvertantly deleted in 0.9.2

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -270,9 +270,85 @@ components:
       properties:
         message:
           $ref: '#/components/schemas/Message'
+        bypass_cache:
+          type: string
+          example: 'true'
+          description: >-
+            Set to true in order to bypass any possible cached message and try to
+            answer the query over again
+        asynchronous:
+          type: string
+          example: 'false'
+          description: >-
+            Set to true in order to receive an incomplete message_id if the query
+            will take a while. Client can then periodically request that
+            message_id for a status update and eventual complete message
+        max_results:
+          type: integer
+          example: 100
+          description: Maximum number of individual results to return
+        page_size:
+          type: integer
+          example: 20
+          description: Split the results into pages with this number of results each
+        page_number:
+          type: integer
+          example: 1
+          description: >-
+            Page number of results when the number of results exceeds the
+            page_size
+        reasoner_ids:
+          type: array
+          example:
+            - RTX
+            - Robokop
+          description: List of reasoners to consult for the query
+          items:
+            type: string
+        previous_message_processing_plan:
+          type: object
+          description: >-
+            Container for one or more Message objects or identifiers for one or
+            more Messages along with a processing plan for how those messages
+            should be processed and returned
+          items:
+            $ref: '#/components/schemas/PreviousMessageProcessingPlan'
       additionalProperties: true
       required:
         - message
+    PreviousMessageProcessingPlan:
+      type: object
+      properties:
+        previous_message_uris:
+          type: array
+          example:
+            - 'https://rtx.ncats.io/api/rtx/v1/message/300'
+          description: List of URIs for Message objects to fetch and process
+          items:
+            type: string
+        previous_messages:
+          type: array
+          description: List of Message objects to process
+          items:
+            $ref: '#/components/schemas/Message'
+        processing_actions:
+          type: array
+          example:
+            - mod45filter
+            - redirect2RTX
+          description: >-
+            List of order-dependent actions to guide what happens with the Message
+            object(s)
+          items:
+            type: string
+        options:
+          type: object
+          example:
+            topNMostFrequent: 1
+          description: >-
+            Dict of options that apply during processing in an order independent
+            fashion
+      additionalProperties: true
     FeedbackResponse:
       type: object
       properties:


### PR DESCRIPTION
These components were present in 0.9.1, but were accidentally deleted in the transition to a core/experimental split in 0.9.2. This PR restores these components to `experimental` branch only.