### PR TITLE
set regex pattern for CURIE and add URL, fixes #400

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1188,8 +1188,7 @@ components:
     URL:
       type: string
       description: >-
-      externalDocs:
-        url: https://www.ietf.org/rfc/rfc3987.txt
+        A Uniform Resource Locator, such as https://www.example.com.
       pattern: ^(http(s)?:\/\/.)?(www\.)?\S+$
     MetaKnowledgeGraph:
       type: object


### PR DESCRIPTION
- regexes are fairly permissive taking into account that CURIE syntax in the "wild" might be less conformant to prefix best practices.
- the ticket called for a URL type, if we want a semantic URI type (where the URI can be the subject of a triple in RDF), then we should be much more restrictive.  When we have a specific use case for this, I'd be happy to refine it. 