### PR TITLE
2nd attempt at required/not-required property handling

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -523,7 +523,6 @@ components:
           items:
             $ref: '#/components/schemas/Result'
           nullable: true
-          minItems: 1
         query_graph:
           description: >-
             QueryGraph object that contains a serialization of a query in the


### PR DESCRIPTION
[one way to address #514 ]

This is a conservative approach to implementing the [9/25 consensus](https://github.com/NCATSTranslator/ReasonerAPI/issues/514#issue-3456069242) + adjustments discussed 10/2. **It does not include anything to address [my concerns and knowledge of the finicky behavior of nullable](https://github.com/NCATSTranslator/ReasonerAPI/issues/514#issuecomment-3363619443).**

The 10/2 adjustments are:
* For not-required properties, I didn't set `nullable` if it had a `default` field or was `type: boolean`
* For NodeBinding/EdgeBinding/AuxGraph/Node `attributes`, I kept `minItems: 0` for now - pending the decision in #520. If the decision is different, change https://github.com/NCATSTranslator/ReasonerAPI/pull/522 first and then merge that branch into this one. 
* For other not-required properties originally set to `minItems: 0` (2 cases), I changed them to `minItems: 1` in an isolated commit. This can be discussed further and easily reverted.



