### PR TITLE
Remove binding, auxgraph attribs

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -668,17 +668,6 @@ components:
             this query_id MUST be provided. In other cases, there is no
             ambiguity, and this query_id SHOULD NOT be provided.
           nullable: true
-        attributes:
-          type: array
-          description: >-
-            A list of attributes providing further information about the
-            node binding. This is not intended for capturing node attributes
-            and should only be used for properties that vary from result to
-            result.
-          items:
-            $ref: '#/components/schemas/Attribute'
-          minItems: 0
-          nullable: true
       additionalProperties: true
       required:
         - id
@@ -793,17 +782,6 @@ components:
           type: string
           description: The key identifier of a specific KnowledgeGraph Edge.
           nullable: false
-        attributes:
-          type: array
-          description: >-
-            A list of attributes providing further information about the
-            edge binding. This is not intended for capturing edge attributes
-            and should only be used for properties that vary from result to
-            result.
-          items:
-            $ref: '#/components/schemas/Attribute'
-          minItems: 0
-          nullable: true
       additionalProperties: true
       required:
         - id
@@ -846,14 +824,6 @@ components:
             type: string
           nullable: false
           minItems: 1
-        attributes:
-          type: array
-          description: >-
-            Attributes of the Auxiliary Graph
-          items:
-            $ref: '#/components/schemas/Attribute'
-          minItems: 0
-          nullable: true
       additionalProperties: true
       required:
         - edges


### PR DESCRIPTION
Another way to address #506, solution 2:

> * remove `attributes` from NodeBinding, EdgeBinding, AuxiliaryGraph (NOT Node!!!). 
>    * Because if no one is using them, they don't need to be specified. Devs can always add them to try out since `additionalProperties: true`.
>    * if we decide to remove them, we can simplify `node_bindings` and `edge_bindings`. See the linked issues. 