### PR TITLE
Add minProperties to QueryGraph.nodes

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -816,6 +816,7 @@ components:
             on bound nodes.
           additionalProperties:
             $ref: '#/components/schemas/QNode'
+          minProperties: 1
         edges:
           type: object
           description: >-


### PR DESCRIPTION
Proposed by @colleenXu in 2026-02-19 meeting, we don't want queries with no nodes to be valid