### PR TITLE
Update ChangeLog for 2.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 - `QEdge.attribute_constraints` and `QEdge.qualifier_constraints`have been removed and replaced with `QEdge.constraints`, which is an object that can contain constraints for `knowledge_level`, `agent_type`, `sources`, `attributes`, and `qualifiers`
 - The new `sources` constraint has ALLOW and DENY constructs with an optional `primary_only` flag
 
-### 2. Add Query.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
+### 2. Add Query.parameters and Response.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
 - Move `Query.log_level` to` Query.parameters.log_level`
 - Move `Query.bypass_cache` to `Query.parameters.bypass_cache`
 - Add `Query.parameters.timeout`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,12 +1,12 @@
 # Change Log  1.6.0-beta (2025-06-06) -> 2.0.0-dev (2026-03-25)
 
-1. QEdge Constraints Refactor (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#1-qedge-constraints-refactor))
+### 1. QEdge Constraints Refactor (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#1-qedge-constraints-refactor))
 - QEdge.attribute_constraints has been removed and replaced with QEdge.constraints, which is an object that can contain constraints for knowledge_level, agent_type, sources, attributes, and qualifiers
 - The new 'sources' constraint has ALLOW and DENY constructs with an optional 'primary_only' flag
 
-2. Add Query.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
+### 2. Add Query.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
 
-3. Binding Structure Changes (NodeBinding/EdgeBinding/PathBinding) (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#3-binding-structure-changes-nodeedgepath))
+### 3. Binding Structure Changes (NodeBinding/EdgeBinding/PathBinding) (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#3-binding-structure-changes-nodeedgepath))
 - <node/edge/path>_bindings are now minProperties: 1 (i.e. when these fields are present, they MUST contain data)
 - `id` properties renamed to `ids` and is now a list
 - `ids` arrays are minItems: 1 (this property is required)
@@ -14,32 +14,32 @@
 - `query_id` was removed from NodeBinding (obsolete with the current subclassing behavior)
 - Each binding is now an object containing only `ids` (which contains is a list), instead of a list of objects each with `id` and `attributes`
 
-4. KL/AT turned into top-level Edge properties, now required (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#4-klat-turned-into-top-level-edge-properties-now-required))
+### 4. KL/AT turned into top-level Edge properties, now required (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#4-klat-turned-into-top-level-edge-properties-now-required))
 - Edge.knowledge_level and Edge.agent_type are now required Edge properties instead of being located within 'attributes'
 
-5. Add COLLATE option to QNode.set_interpretation enum (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#5-add-collate-option-to-qnodeset_interpretation))
+### 5. Add COLLATE option to QNode.set_interpretation enum (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#5-add-collate-option-to-qnodeset_interpretation))
 
-6. null is no longer a valid value in queries and responses (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#6-null-is-no-longer-a-valid-value-in-queries-and-responses))
+### 6. null is no longer a valid value in queries and responses (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#6-null-is-no-longer-a-valid-value-in-queries-and-responses))
 - Remove `nullable: true/false` designations for all properties. Properties with no data must now be *absent* from TRAPI JSON rather than allowed to be present but with a null value
 
-7. Many optional properties set to <minItems/minProperties>: 1 
+### 7. Many optional properties set to <minItems/minProperties>: 1 
 - Empty lists are no longer permitted to say "no data". "No data" is now expressed with an absent property
 - ****** list them
 
-8. Remove AuxiliaryGraph.attributes property
+### 8. Remove AuxiliaryGraph.attributes property
 
-9. The following properties changed to not-required
+### 9. The following properties changed to not-required
 - `Nodes.attributes` (to reduce bloat)
 - `QueryGraph.edges` and `QueryGraph.paths` (to accommodate queries with only nodes) (e.g. "what are the attributes of CURIE:123?")
 - `KnowledgeGraph.edges` (to accommodate queries with only nodes)
 - `Result.analyses` (to accommodate queries with only nodes)
 
-10. Analysis is technically allowed to have both edge and path bindings (experimental use)
+### 10. Analysis is technically allowed to have both edge and path bindings (experimental use)
 
-11. YAML specification document5 migrated from OpenAPI 3.0.1 to OpenAPI 3.1.2
+### 11. YAML specification document5 migrated from OpenAPI 3.0.1 to OpenAPI 3.1.2
 - All `example` attributes become `examples` in OpenAPI 3.1.2
 
-12. BaseQueryGraph and BaseAnalysis base classes removed in favor of single QueryGraph and Analysis classes that support both pathfinder and regular queries
+### 12. BaseQueryGraph and BaseAnalysis base classes removed in favor of single QueryGraph and Analysis classes that support both pathfinder and regular queries
 
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,11 +25,10 @@
 ### 5. Add COLLATE option to QNode.set_interpretation enum (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#5-add-collate-option-to-qnodeset_interpretation))
 
 ### 6. null is no longer a valid value in queries and responses (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#6-null-is-no-longer-a-valid-value-in-queries-and-responses))
-- Remove `nullable: true/false` designations for all properties. Properties with no data must now be *absent* from TRAPI JSON rather than allowed to be present but with a null value
+- Remove `nullable: true/false` designations for all properties. Properties with no data must now be *absent* from TRAPI JSON or an empty array/object if the schema allows, rather than allowed to be present but with a null value. Some field descriptions explicitly state that the empty array/object MUST be used in certain circumstances.
 
 ### 7. Many optional properties set to <minItems/minProperties>: 1 
-- Empty lists are no longer permitted to say "no data here". "No data" is now expressed with an absent property
-- This affects the following properties:
+In the following properties, empty lists are no longer permitted to say "no data here". "No data" is now expressed with an absent property:
 - `QueryGraph.nodes`
 - `QueryGraph.edges`
 - `Response.logs`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -45,6 +45,7 @@ In the following properties, empty lists are no longer permitted to say "no data
 - `RetrievalSource.source_record_urls`
 
 ### 8. Removed AuxiliaryGraph.attributes property
+- It was previously required, but never used and its empty arrays bloated responses. Additional undefined properties are still allowed in AuxiliaryGraph objects.
 
 ### 9. The following properties changed to not-required
 - `Nodes.attributes` (to reduce bloat)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 - The new `sources` constraint has ALLOW and DENY constructs with an optional `primary_only` flag
 
 ### 2. Add Query.parameters and Response.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
-- Move `Query.log_level` to` Query.parameters.log_level`
+- Move `Query.log_level` to `Query.parameters.log_level`
 - Move `Query.bypass_cache` to `Query.parameters.bypass_cache`
 - Add `Query.parameters.timeout`
 - Add `Response.parameters` that conveys the same parameters as `Query.parameters`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@
 - The new 'sources' constraint has ALLOW and DENY constructs with an optional 'primary_only' flag
 
 ### 2. Add Query.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
+- Move Query.log_level to Query.parameters.log_level
+- Move Query.bypass_cache to Query.parameters.bypass_cache
+- Add Query.parameters.timeout
+- Add Response.parameters that conveys the same parameters as Query.parameters
+- Add HTTP 409 code
 
 ### 3. Binding Structure Changes (NodeBinding/EdgeBinding/PathBinding) (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#3-binding-structure-changes-nodeedgepath))
 - <node/edge/path>_bindings are now minProperties: 1 (i.e. when these fields are present, they MUST contain data)
@@ -24,7 +29,20 @@
 
 ### 7. Many optional properties set to <minItems/minProperties>: 1 
 - Empty lists are no longer permitted to say "no data". "No data" is now expressed with an absent property
-- ****** list them
+- QueryGraph.nodes
+- QueryGraph.edges
+- Response.logs
+- Message.auxiliary_graphs
+- Result.analyses
+- Analysis.support_graphs
+- QNode.member_ids
+- QNode.constraints
+- Edge.qualifiers
+- MetaKnowledgeGraph.nodes
+- MetaEdge.qualifiers
+- MetaQualifier.applicable_values
+- RetrievalSource.upstream_resource_ids
+- RetrievalSource.source_record_urls
 
 ### 8. Remove AuxiliaryGraph.attributes property
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,34 @@
-# Change Log TRAPI 1.4.0 (2023-06-23) -> 1.5.0 (2023-05-26)
+# Change Log  1.6.0-beta (2025-06-06) -> 2.0.0-dev (2026-03-01)
+
+- Migrate from OpenAPI 3.0.1 to OpenAPI 3.1.2 specification (Note that 'example' becomes 'examples' in OpenAPI 3.1.2)
+
+- Add Query.parameters to contain additional and extensible query parameters
+
+- QEdge.attribute_constraints has been renamed to QEdge.constraints which is an object that can contain constraints for knowledge_level, agent_type, attributes, qualifiers, and sources
+
+- A separate 'sources' constraint now has ALLOW and DENY constructs with an optional 'primary_only' flag
+
+- Edge.knowledge_level and Edge.agent_type are now direct Edge properties instead of within 'attributes'
+
+- The 'attributes' property is no longer required
+
+- Remove all 'nullable' attributes. Properties with no data must now be *absent* from TRAPI JSON rather than allowed to be present but with a null value
+
+- Remove 'attributes' from NodeBinding and EdgeBinding
+
+- Empty lists no longer permitted to say "no data". Must now be absent property
+
+- BaseQueryGraph and BaseAnalysis base classes removed in favor of a single QueryGraph and Analysis that support both pathfinder and regular queries
+
+- EdgeBinding has been simplified
+
+- Add new enumerated value COLLATE for QNode.set_interpretation
+
+# Change Log TRAPI 1.5.0 (2024-05-26) -> 1.6.0-beta (2025-06-06)
+
+- TBD
+
+# Change Log TRAPI 1.4.0 (2023-06-23) -> 1.5.0 (2024-05-26)
 
 https://github.com/NCATSTranslator/ReasonerAPI/compare/v1.4.0...1.5
   

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -60,9 +60,11 @@
 
 ### 12. BaseQueryGraph and BaseAnalysis base classes removed in favor of single QueryGraph and Analysis classes that support both pathfinder and regular queries
 
+.
 
+.
 
-
+.
 
 # Change Log TRAPI 1.5.0 (2024-05-26) -> 1.6.0-beta (2025-06-06)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,17 +1,17 @@
 # Change Log  1.6.0-beta (2025-06-06) -> 2.0.0-dev (2026-03-25)
 
-### 1. QEdge Constraints Refactor (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#1-qedge-constraints-refactor))
-- `QEdge.attribute_constraints` has been removed and replaced with `QEdge.constraints`, which is an object that can contain constraints for `knowledge_level`, `agent_type`, `sources`, `attributes`, and `qualifiers`
+### 1. QEdge Constraints Refactor (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#1-qedge-constraints-refactor))
+- `QEdge.attribute_constraints` and `QEdge.qualifier_constraints`have been removed and replaced with `QEdge.constraints`, which is an object that can contain constraints for `knowledge_level`, `agent_type`, `sources`, `attributes`, and `qualifiers`
 - The new `sources` constraint has ALLOW and DENY constructs with an optional `primary_only` flag
 
-### 2. Add Query.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
+### 2. Add Query.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
 - Move `Query.log_level` to` Query.parameters.log_level`
 - Move `Query.bypass_cache` to `Query.parameters.bypass_cache`
 - Add `Query.parameters.timeout`
 - Add `Response.parameters` that conveys the same parameters as `Query.parameters`
 - Add HTTP 409 code
 
-### 3. Binding Structure Changes (NodeBinding/EdgeBinding/PathBinding) (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#3-binding-structure-changes-nodeedgepath))
+### 3. Binding Structure Changes (NodeBinding/EdgeBinding/PathBinding) (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#3-binding-structure-changes-nodeedgepath))
 - `<node/edge/path>_bindings` are now minProperties: 1 (i.e. when these fields are present, they MUST contain data)
 - `id` properties renamed to `ids` and is now a list
 - `ids` arrays are minItems: 1 (this property is required)
@@ -19,12 +19,12 @@
 - `query_id` was removed from NodeBinding (obsolete with the current subclassing behavior)
 - Each binding is now an object containing only `ids` (which contains is a list), instead of a list of objects each with `id` and `attributes`
 
-### 4. KL/AT turned into top-level Edge properties, now required (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#4-klat-turned-into-top-level-edge-properties-now-required))
+### 4. KL/AT turned into top-level Edge properties, now required (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#4-klat-turned-into-top-level-edge-properties-now-required))
 - `Edge.knowledge_level` and `Edge.agent_type` are now required `Edge` properties instead of being located within `attributes`
 
-### 5. Add COLLATE option to QNode.set_interpretation enum (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#5-add-collate-option-to-qnodeset_interpretation))
+### 5. Add COLLATE option to QNode.set_interpretation enum (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#5-add-collate-option-to-qnodeset_interpretation))
 
-### 6. null is no longer a valid value in queries and responses (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#6-null-is-no-longer-a-valid-value-in-queries-and-responses))
+### 6. null is no longer a valid value in queries and responses (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#6-null-is-no-longer-a-valid-value-in-queries-and-responses))
 - Remove `nullable: true/false` designations for all properties. Properties with no data must now be *absent* from TRAPI JSON rather than allowed to be present but with a null value
 
 ### 7. Many optional properties set to <minItems/minProperties>: 1 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,7 @@
 - `ids` arrays are minItems: 1 (this property is required)
 - `attributes` property completely removed
 - `query_id` was removed from NodeBinding (obsolete with the current subclassing behavior)
-- Each binding is now an object containing only `ids` (which contains a list), instead of a list of objects each with `id` and `attributes`
+- Each binding is now an object containing only `ids` (which is a list), instead of a list of objects each with `id` and `attributes`
 
 ### 4. KL/AT turned into top-level Edge properties, now required (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#4-klat-turned-into-top-level-edge-properties-now-required))
 - `Edge.knowledge_level` and `Edge.agent_type` are now required `Edge` properties instead of being located within `attributes`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,7 +44,7 @@ In the following properties, empty lists are no longer permitted to say "no data
 - `RetrievalSource.upstream_resource_ids`
 - `RetrievalSource.source_record_urls`
 
-### 8. Remove AuxiliaryGraph.attributes property
+### 8. Removed AuxiliaryGraph.attributes property
 
 ### 9. The following properties changed to not-required
 - `Nodes.attributes` (to reduce bloat)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,7 @@
 - `ids` arrays are minItems: 1 (this property is required)
 - `attributes` property completely removed
 - `query_id` was removed from NodeBinding (obsolete with the current subclassing behavior)
-- Each binding is now an object containing only `ids` (which contains is a list), instead of a list of objects each with `id` and `attributes`
+- Each binding is now an object containing only `ids` (which contains a list), instead of a list of objects each with `id` and `attributes`
 
 ### 4. KL/AT turned into top-level Edge properties, now required (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#4-klat-turned-into-top-level-edge-properties-now-required))
 - `Edge.knowledge_level` and `Edge.agent_type` are now required `Edge` properties instead of being located within `attributes`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,28 +1,49 @@
-# Change Log  1.6.0-beta (2025-06-06) -> 2.0.0-dev (2026-03-01)
+# Change Log  1.6.0-beta (2025-06-06) -> 2.0.0-dev (2026-03-25)
 
-- Migrate from OpenAPI 3.0.1 to OpenAPI 3.1.2 specification (Note that 'example' becomes 'examples' in OpenAPI 3.1.2)
+1. QEdge Constraints Refactor (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#1-qedge-constraints-refactor))
+- QEdge.attribute_constraints has been removed and replaced with QEdge.constraints, which is an object that can contain constraints for knowledge_level, agent_type, sources, attributes, and qualifiers
+- The new 'sources' constraint has ALLOW and DENY constructs with an optional 'primary_only' flag
 
-- Add Query.parameters to contain additional and extensible query parameters
+2. Add Query.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
 
-- QEdge.attribute_constraints has been renamed to QEdge.constraints which is an object that can contain constraints for knowledge_level, agent_type, attributes, qualifiers, and sources
+3. Binding Structure Changes (NodeBinding/EdgeBinding/PathBinding) (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#3-binding-structure-changes-nodeedgepath))
+- <node/edge/path>_bindings are now minProperties: 1 (i.e. when these fields are present, they MUST contain data)
+- `id` properties renamed to `ids` and is now a list
+- `ids` arrays are minItems: 1 (this property is required)
+- `attributes` property completely removed
+- `query_id` was removed from NodeBinding (obsolete with the current subclassing behavior)
+- Each binding is now an object containing only `ids` (which contains is a list), instead of a list of objects each with `id` and `attributes`
 
-- A separate 'sources' constraint now has ALLOW and DENY constructs with an optional 'primary_only' flag
+4. KL/AT turned into top-level Edge properties, now required (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#4-klat-turned-into-top-level-edge-properties-now-required))
+- Edge.knowledge_level and Edge.agent_type are now required Edge properties instead of being located within 'attributes'
 
-- Edge.knowledge_level and Edge.agent_type are now direct Edge properties instead of within 'attributes'
+5. Add COLLATE option to QNode.set_interpretation enum (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#5-add-collate-option-to-qnodeset_interpretation))
 
-- The 'attributes' property is no longer required
+6. null is no longer a valid value in queries and responses (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#6-null-is-no-longer-a-valid-value-in-queries-and-responses))
+- Remove `nullable: true/false` designations for all properties. Properties with no data must now be *absent* from TRAPI JSON rather than allowed to be present but with a null value
 
-- Remove all 'nullable' attributes. Properties with no data must now be *absent* from TRAPI JSON rather than allowed to be present but with a null value
+7. Many optional properties set to <minItems/minProperties>: 1 
+- Empty lists are no longer permitted to say "no data". "No data" is now expressed with an absent property
+- ****** list them
 
-- Remove 'attributes' from NodeBinding and EdgeBinding
+8. Remove AuxiliaryGraph.attributes property
 
-- Empty lists no longer permitted to say "no data". Must now be absent property
+9. The following properties changed to not-required
+- `Nodes.attributes` (to reduce bloat)
+- `QueryGraph.edges` and `QueryGraph.paths` (to accommodate queries with only nodes) (e.g. "what are the attributes of CURIE:123?")
+- `KnowledgeGraph.edges` (to accommodate queries with only nodes)
+- `Result.analyses` (to accommodate queries with only nodes)
 
-- BaseQueryGraph and BaseAnalysis base classes removed in favor of a single QueryGraph and Analysis that support both pathfinder and regular queries
+10. Analysis is technically allowed to have both edge and path bindings (experimental use)
 
-- EdgeBinding has been simplified
+11. YAML specification document5 migrated from OpenAPI 3.0.1 to OpenAPI 3.1.2
+- All `example` attributes become `examples` in OpenAPI 3.1.2
 
-- Add new enumerated value COLLATE for QNode.set_interpretation
+12. BaseQueryGraph and BaseAnalysis base classes removed in favor of single QueryGraph and Analysis classes that support both pathfinder and regular queries
+
+
+
+
 
 # Change Log TRAPI 1.5.0 (2024-05-26) -> 1.6.0-beta (2025-06-06)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -67,9 +67,10 @@
 # Change Log TRAPI 1.5.0 (2024-05-26) -> 1.6.0-beta (2025-06-06)
 
 - Diff: https://github.com/NCATSTranslator/ReasonerAPI/compare/1.5...1.6
+- TRAPI 1.6.0-beta was designed to be backwards compatible while adding support for Pathfinder queries. Any valid TRAPI 1.5.0 document is also a valid TRAPI 1.6.0 document.
 - Split `QueryGraph` into `BaseQueryGraph`, `PathfinderQueryGraph` (for Pathfinder support), and `QueryGraph` (for all other queries). The latter two classes inherit from `BaseQueryGraph`
 - Split `Analysis` into `BaseAnalysis`, `PathfinderAnalysis` (for Pathfinder support), and `Analysis` (for all other queries). The latter two classes inherit from `BaseAnalysis`
-- Add `PathfinderQueryGraph.QPath` class containing properties `subject`, `objec`t, `predicates`, and `constraints`
+- Add `PathfinderQueryGraph.QPath` class containing properties `subject`, `object`, `predicates`, and `constraints`
 
 =============
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,18 +1,18 @@
 # Change Log  1.6.0-beta (2025-06-06) -> 2.0.0-dev (2026-03-25)
 
 ### 1. QEdge Constraints Refactor (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#1-qedge-constraints-refactor))
-- QEdge.attribute_constraints has been removed and replaced with QEdge.constraints, which is an object that can contain constraints for knowledge_level, agent_type, sources, attributes, and qualifiers
-- The new 'sources' constraint has ALLOW and DENY constructs with an optional 'primary_only' flag
+- `QEdge.attribute_constraints` has been removed and replaced with `QEdge.constraints`, which is an object that can contain constraints for `knowledge_level`, `agent_type`, `sources`, `attributes`, and `qualifiers`
+- The new `sources` constraint has ALLOW and DENY constructs with an optional `primary_only` flag
 
 ### 2. Add Query.parameters to contain existing log_level and bypass_cache parameters and add timeout query parameter (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#2-new-queryresponse-parameters))
-- Move Query.log_level to Query.parameters.log_level
-- Move Query.bypass_cache to Query.parameters.bypass_cache
-- Add Query.parameters.timeout
-- Add Response.parameters that conveys the same parameters as Query.parameters
+- Move `Query.log_level` to` Query.parameters.log_level`
+- Move `Query.bypass_cache` to `Query.parameters.bypass_cache`
+- Add `Query.parameters.timeout`
+- Add `Response.parameters` that conveys the same parameters as `Query.parameters`
 - Add HTTP 409 code
 
 ### 3. Binding Structure Changes (NodeBinding/EdgeBinding/PathBinding) (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#3-binding-structure-changes-nodeedgepath))
-- <node/edge/path>_bindings are now minProperties: 1 (i.e. when these fields are present, they MUST contain data)
+- `<node/edge/path>_bindings` are now minProperties: 1 (i.e. when these fields are present, they MUST contain data)
 - `id` properties renamed to `ids` and is now a list
 - `ids` arrays are minItems: 1 (this property is required)
 - `attributes` property completely removed
@@ -20,7 +20,7 @@
 - Each binding is now an object containing only `ids` (which contains is a list), instead of a list of objects each with `id` and `attributes`
 
 ### 4. KL/AT turned into top-level Edge properties, now required (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#4-klat-turned-into-top-level-edge-properties-now-required))
-- Edge.knowledge_level and Edge.agent_type are now required Edge properties instead of being located within 'attributes'
+- `Edge.knowledge_level` and `Edge.agent_type` are now required `Edge` properties instead of being located within `attributes`
 
 ### 5. Add COLLATE option to QNode.set_interpretation enum (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0-migration-guide-plus/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#5-add-collate-option-to-qnodeset_interpretation))
 
@@ -28,21 +28,22 @@
 - Remove `nullable: true/false` designations for all properties. Properties with no data must now be *absent* from TRAPI JSON rather than allowed to be present but with a null value
 
 ### 7. Many optional properties set to <minItems/minProperties>: 1 
-- Empty lists are no longer permitted to say "no data". "No data" is now expressed with an absent property
-- QueryGraph.nodes
-- QueryGraph.edges
-- Response.logs
-- Message.auxiliary_graphs
-- Result.analyses
-- Analysis.support_graphs
-- QNode.member_ids
-- QNode.constraints
-- Edge.qualifiers
-- MetaKnowledgeGraph.nodes
-- MetaEdge.qualifiers
-- MetaQualifier.applicable_values
-- RetrievalSource.upstream_resource_ids
-- RetrievalSource.source_record_urls
+- Empty lists are no longer permitted to say "no data here". "No data" is now expressed with an absent property
+- This affects the following properties:
+- `QueryGraph.nodes`
+- `QueryGraph.edges`
+- `Response.logs`
+- `Message.auxiliary_graphs`
+- `Result.analyses`
+- `Analysis.support_graphs`
+- `QNode.member_ids`
+- `QNode.constraints`
+- `Edge.qualifiers`
+- `MetaKnowledgeGraph.nodes`
+- `MetaEdge.qualifiers`
+- `MetaQualifier.applicable_values`
+- `RetrievalSource.upstream_resource_ids`
+- `RetrievalSource.source_record_urls`
 
 ### 8. Remove AuxiliaryGraph.attributes property
 
@@ -54,7 +55,7 @@
 
 ### 10. Analysis is technically allowed to have both edge and path bindings (experimental use)
 
-### 11. YAML specification document5 migrated from OpenAPI 3.0.1 to OpenAPI 3.1.2
+### 11. YAML specification document migrated from OpenAPI 3.0.1 to OpenAPI 3.1.2
 - All `example` attributes become `examples` in OpenAPI 3.1.2
 
 ### 12. BaseQueryGraph and BaseAnalysis base classes removed in favor of single QueryGraph and Analysis classes that support both pathfinder and regular queries

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -60,11 +60,9 @@
 
 ### 12. BaseQueryGraph and BaseAnalysis base classes removed in favor of single QueryGraph and Analysis classes that support both pathfinder and regular queries
 
-.
+=============
 
-.
 
-.
 
 # Change Log TRAPI 1.5.0 (2024-05-26) -> 1.6.0-beta (2025-06-06)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -66,7 +66,12 @@
 
 # Change Log TRAPI 1.5.0 (2024-05-26) -> 1.6.0-beta (2025-06-06)
 
-- TBD
+- Diff: https://github.com/NCATSTranslator/ReasonerAPI/compare/1.5...1.6
+- Split `QueryGraph` into `BaseQueryGraph`, `PathfinderQueryGraph` (for Pathfinder support), and `QueryGraph` (for all other queries). The latter two classes inherit from `BaseQueryGraph`
+- Split `Analysis` into `BaseAnalysis`, `PathfinderAnalysis` (for Pathfinder support), and `Analysis` (for all other queries). The latter two classes inherit from `BaseAnalysis`
+- Add `PathfinderQueryGraph.QPath` class containing properties `subject`, `objec`t, `predicates`, and `constraints`
+
+=============
 
 # Change Log TRAPI 1.4.0 (2023-06-23) -> 1.5.0 (2024-05-26)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,7 +2,7 @@
 
 ## Components
 
-#### Query [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L277:L315)
+#### Query [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L277:L315)
 
 The Query class is used to package a user request for information. A Query object consists of a required Message object with optional additional properties. Additional properties are intended to convey implementation-specific or query-independent parameters. For example, an additional property specifying a log level could allow a user to override the default log level in order to receive more fine-grained log information when debugging an issue.
 ##### Fixed Fields
@@ -14,7 +14,7 @@ The Query class is used to package a user request for information. A Query objec
 | message | [Message](#message-) | **REQUIRED**. The query Message is a serialization of the user request. Content of the Message object depends on the intended TRAPI operation. For example, the fill operation requires a non-empty query_graph field as part of the Message, whereas other operations, e.g. overlay, require non-empty results and knowledge_graph fields. |
 | workflow | [workflow](#workflow-) | List of workflow steps to be executed. |
 
-#### AsyncQuery [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L316:L339)
+#### AsyncQuery [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L316:L339)
 
 The AsyncQuery class is effectively the same as the Query class but it requires a callback property.
 
@@ -27,7 +27,7 @@ The AsyncQuery class is effectively the same as the Query class but it requires 
 | --- | :---: | --- |
 | callback | `string` | **REQUIRED**. Upon completion, this server will send a POST request to the callback URL with `Content-Type: application/json` header and request body containing a JSON-encoded `Response` object. The server MAY POST `Response` objects before work is fully complete to provide interim results with a Response.status value of 'Running'. If a POST operation to the callback URL does not succeed, the server SHOULD retry the POST at least once. |
 
-#### QueryParameters [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L340:L371)
+#### QueryParameters [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L340:L371)
 
 Query-time parameters that don't affect the semantics of a query or intended workflow, but may affect overall behavior of the server in the execution of this query. The server MUST maintain parameters it is given in the response.
 ##### Fixed Fields
@@ -38,7 +38,7 @@ Query-time parameters that don't affect the semantics of a query or intended wor
 | log_level | [LogLevel](#loglevel-) | The least critical level of logs to return. |
 | bypass_cache | `boolean` | Set to true in order to request that the agent obtain fresh information from its sources in all cases where it has a viable choice between requesting fresh information in real time and using cached information. The agent receiving this flag MUST also include it in TRAPI sent to downstream sources (e.g., ARS -> ARAs -> KPs). |
 
-#### AsyncQueryResponse [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L372:L402)
+#### AsyncQueryResponse [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L372:L402)
 
 The AsyncQueryResponse object contains a payload that must be returned from a submitted async_query.
 ##### Fixed Fields
@@ -49,7 +49,7 @@ The AsyncQueryResponse object contains a payload that must be returned from a su
 | description | `string` | A brief human-readable description of the result of the async_query submission. |
 | job_id | `string` | **REQUIRED**. An identifier for the submitted job that can be used with /async_query_status to receive an update on the status of the job. |
 
-#### AsyncQueryStatusResponse [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L403:L445)
+#### AsyncQueryStatusResponse [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L403:L445)
 
 The AsyncQueryStatusResponse object contains a payload that describes the current status of a previously submitted async_query.
 ##### Fixed Fields
@@ -61,7 +61,7 @@ The AsyncQueryStatusResponse object contains a payload that describes the curren
 | logs | Array\[[LogEntry](#logentry-)\] | **REQUIRED**. **Minimum items: 1** A list of LogEntry items, containing errors, warnings, debugging information, etc. List items MUST be in chronological order with earliest first. The most recent entry should be last. Its timestamp will be compared against the current time to see if there is still activity. |
 | response_url | `string` | Optional URL that can be queried to restrieve the full TRAPI Response. |
 
-#### Response [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L446:L502)
+#### Response [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L446:L502)
 
 The Response object contains the main payload when a TRAPI query endpoint interprets and responds to the submitted query successfully (i.e., HTTP Status Code 200). The message property contains the knowledge of the response (query graph, knowledge graph, and results). The status, description, and logs properties provide additional details about the response.
 ##### Fixed Fields
@@ -77,7 +77,7 @@ The Response object contains the main payload when a TRAPI query endpoint interp
 | schema_version | `string` | Version label of the TRAPI schema used in this document |
 | biolink_version | `string` | Version label of the Biolink model used in this document |
 
-#### Message [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L503:L546)
+#### Message [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L503:L546)
 
 The message object holds the main content of a Query or a Response in three properties: query_graph, results, and knowledge_graph. The query_graph property contains the query configuration, the results property contains any answers that are returned by the service, and knowledge_graph property contains lists of edges and nodes in the thought graph corresponding to this message. The content of these properties is context-dependent to the encompassing object and the TRAPI operation requested.
 ##### Fixed Fields
@@ -89,7 +89,7 @@ The message object holds the main content of a Query or a Response in three prop
 | knowledge_graph | [KnowledgeGraph](#knowledgegraph-) | KnowledgeGraph object that contains lists of nodes and edges in the thought graph corresponding to the message |
 | auxiliary_graphs | Map\[`string`, [AuxiliaryGraph](#auxiliarygraph-)\] | **Minimum properties: 1** Dictionary of AuxiliaryGraph instances that are used by Knowledge Graph Edges and Result Analyses. These are referenced elsewhere by the dictionary key. |
 
-#### LogEntry [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L547:L584)
+#### LogEntry [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L547:L584)
 
 The LogEntry object contains information useful for tracing and debugging across Translator components.  Although an individual component (for example, an ARA or KP) may have its own logging and debugging infrastructure, this internal information is not, in general, available to other components. In addition to a timestamp and logging level, LogEntry includes a string intended to be read by a human, along with one of a standardized set of codes describing the condition of the component sending the message.
 ##### Fixed Fields
@@ -101,7 +101,7 @@ The LogEntry object contains information useful for tracing and debugging across
 | code | `string` | One of a standardized set of short codes e.g. QueryNotTraversable, KPNotAvailable, KPResponseMalformed |
 | message | `string` | **REQUIRED**. A human-readable log message |
 
-#### LogLevel [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L585:L592)
+#### LogLevel [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L585:L592)
 
 Logging level
 `string`
@@ -113,7 +113,7 @@ one of:
 - INFO
 - DEBUG
 
-#### Result [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L593:L623)
+#### Result [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L593:L623)
 
 A Result object specifies the nodes and edges in the knowledge graph that satisfy the structure or conditions of a user-submitted query graph. It must contain a NodeBindings object (list of query graph node to knowledge graph node mappings) and a list of Analysis objects.
 ##### Fixed Fields
@@ -123,7 +123,7 @@ A Result object specifies the nodes and edges in the knowledge graph that satisf
 | node_bindings | Map\[`string`, [NodeBinding](#nodebinding-)\] | **REQUIRED**. **Minimum properties: 1** The dictionary of Input Query Graph to Result Knowledge Graph node bindings where the dictionary keys are the key identifiers of the Query Graph nodes and the associated values of those keys are instances of NodeBinding schema type (see below). Because a given QNode may have multiple knowledge Nodes bound in the result, the NodeBinding object may list multiple knowledge Nodes. |
 | analyses | Array\[[Analysis](#analysis-)\] | **Minimum items: 1** The list of all Analysis components that contribute to the result. See below for Analysis components. |
 
-#### NodeBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L624:L643)
+#### NodeBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L624:L643)
 
 A NodeBinding object defines all relevant KnowledgeGraph Node mappings, identified by the corresponding object key identifier(s) of the Node(s) within the Knowledge Graph. Instances of NodeBinding may include extra annotation in the form of additional properties. (such annotation is not yet fully standardized). Each Node Binding must bind directly to node in the original Query Graph.
 ##### Fixed Fields
@@ -132,7 +132,7 @@ A NodeBinding object defines all relevant KnowledgeGraph Node mappings, identifi
 | --- | :---: | --- |
 | ids | Array\[[CURIE](#curie-)\] | **REQUIRED**. **Minimum items: 1** The CURIEs of one or more Nodes within the Knowledge Graph. |
 
-#### Analysis [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L644:L713)
+#### Analysis [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L644:L713)
 
 An analysis is a dictionary that contains information about the result tied to a particular service. Each Analysis is generated by a single reasoning service, and describes the outputs of analyses performed by the reasoner on a particular Result (e.g. a result score), along with provenance information supporting the analysis (e.g. method or data that supported generation of the score).
 ##### Fixed Fields
@@ -147,7 +147,7 @@ An analysis is a dictionary that contains information about the result tied to a
 | scoring_method | `string` | An identifier and link to an explanation for the method used to generate the score |
 | attributes | Array\[[Attribute](#attribute-)\] | The attributes of this particular Analysis. |
 
-#### EdgeBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L714:L733)
+#### EdgeBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L714:L733)
 
 An EdgeBinding object defines all relevant KnowledgeGraph Edge mappings, identified by the corresponding 'id' object key identifier of the Edge within the Knowledge Graph. Instances of EdgeBinding may include extra annotation (such annotation is not yet fully standardized). Edge bindings are captured within a specific reasoner's Analysis object because the Edges in the Knowledge Graph that get bound to the input Query Graph may differ between reasoners.
 ##### Fixed Fields
@@ -156,7 +156,7 @@ An EdgeBinding object defines all relevant KnowledgeGraph Edge mappings, identif
 | --- | :---: | --- |
 | ids | Array\[`string`\] | **REQUIRED**. **Minimum items: 1** The key identifiers of specific KnowledgeGraph Edges. |
 
-#### PathBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L734:L750)
+#### PathBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L734:L750)
 
 A PathBinding object binds a single QueryGraph path (the key to this object) to one or more relevant AuxiliaryGraph ids containing a list of edges in the path. The Auxiliary Graph does not convey any order of edges in the path.
 ##### Fixed Fields
@@ -165,7 +165,7 @@ A PathBinding object binds a single QueryGraph path (the key to this object) to 
 | --- | :---: | --- |
 | ids | Array\[`string`\] | **REQUIRED**. **Minimum items: 1** The key identifiers of specific auxiliary graphs. |
 
-#### AuxiliaryGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L751:L776)
+#### AuxiliaryGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L751:L776)
 
 A single AuxiliaryGraph instance that is used by Knowledge Graph Edges, Result Analysis support graphs, and Path Bindings. Edges comprising an Auxiliary Graph are a subset of the Knowledge Graph in the message. Data creators can create an AuxiliaryGraph to assemble a specific collection of edges from the Knowledge Graph into a named graph that can be referenced from an Edge as evidence/explanation supporting that Edge, from a Result Analysis as information used to generate a score, or from a Path Binding as the path for that Analysis.
 ##### Fixed Fields
@@ -174,7 +174,7 @@ A single AuxiliaryGraph instance that is used by Knowledge Graph Edges, Result A
 | --- | :---: | --- |
 | edges | Array\[`string`\] | **REQUIRED**. **Minimum items: 1** List of edges that form the Auxiliary Graph. Each item is a reference to a single Knowledge Graph Edge. This list is not ordered, nor is the order intended to convey any relationship between the edges that form this Auxiliary Graph. |
 
-#### KnowledgeGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L777:L803)
+#### KnowledgeGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L777:L803)
 
 The knowledge graph associated with a set of results. The instances of Node and Edge defining this graph represent instances of biolink:NamedThing (concept nodes) and biolink:Association (relationship edges) representing (Attribute) annotated knowledge returned from the knowledge sources and inference agents wrapped by the given TRAPI implementation.
 ##### Fixed Fields
@@ -184,7 +184,7 @@ The knowledge graph associated with a set of results. The instances of Node and 
 | nodes | Map\[`string`, [Node](#node-)\] | **REQUIRED**. Dictionary of Node instances used in the KnowledgeGraph, referenced elsewhere in the TRAPI output by the dictionary key. |
 | edges | Map\[`string`, [Edge](#edge-)\] | Dictionary of Edge instances used in the KnowledgeGraph, referenced elsewhere in the TRAPI output by the dictionary key. |
 
-#### QueryGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L804:L844)
+#### QueryGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L804:L844)
 
 A graph representing a biomedical question. It serves as a template for each result (answer), where each bound knowledge graph node/edge is expected to obey the constraints of the associated query graph element.
 ##### Fixed Fields
@@ -195,7 +195,7 @@ A graph representing a biomedical question. It serves as a template for each res
 | edges | Map\[`string`, [QEdge](#qedge-)\] | **Minimum properties: 1** The edge specifications. The keys of this map are unique edge identifiers and the corresponding values include the constraints on bound edges, in addition to specifying the subject and object QNodes. |
 | paths | Map\[`string`, [QPath](#qpath-)\] | **Minimum properties: 1** The QueryGraph path specification, used only for pathfinder type queries. The keys of this map are unique path identifiers and the corresponding values include the constraints on bound paths, in addition to specifying the subject, object, and intermediate QNodes. |
 
-#### QNode [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L845:L920)
+#### QNode [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L845:L920)
 
 A node in the QueryGraph used to represent an entity in a query. If a CURIE is not specified, any nodes matching the category of the QNode will be returned in the Results.
 ##### Fixed Fields
@@ -208,7 +208,7 @@ A node in the QueryGraph used to represent an entity in a query. If a CURIE is n
 | member_ids | Array\[[CURIE](#curie-)\] | **Minimum items: 1** A list of CURIE identifiers for members of a queried set. This field MUST be populated under a set_interpretation of MANY or ALL, when the 'ids' field holds a UUID representing the set itself. This field MUST NOT be used under a set_interpretation of BATCH or COLLATE or when set_interpretation is absent. |
 | constraints | Array\[[AttributeConstraint](#attributeconstraint-)\] | **Minimum items: 1** A list of constraints applied to a query node. If there are multiple items, they must all be true (equivalent to AND) |
 
-#### QEdge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L921:L981)
+#### QEdge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L921:L981)
 
 An edge in the QueryGraph used as a filter pattern specification in a query. If the optional predicate property is not specified, it is assumed to be a wildcard match to the target knowledge space. If specified, the ontological inheritance hierarchy associated with the term provided is assumed, such that edge bindings returned may be an exact match to the given QEdge predicate term, or to a term that is a descendant of the QEdge predicate term.
 ##### Fixed Fields
@@ -221,7 +221,7 @@ An edge in the QueryGraph used as a filter pattern specification in a query. If 
 | object | `string` | **REQUIRED**. Corresponds to the map key identifier of the object concept node anchoring the query filter pattern for the query relationship edge. |
 | constraints | [QEdgeConstraints](#qedgeconstraints-) | An object containing all constraints placed on the QEdge. ALL edges bound to this QEdge MUST conform to ALL given constraints; underlying edges (such as those appearing in supporting graphs) are not required to conform to the given constraints. |
 
-#### QEdgeConstraints [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L982:L1056)
+#### QEdgeConstraints [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L982:L1056)
 
 A subschema for constraints that may be placed on a given QEdge. ALL edges bound to the given QEdge MUST conform to ALL given constraints; underlying edges (such as those appearing in supporting graphs) are not required to conform to the given constraints.
 ##### Fixed Fields
@@ -234,7 +234,7 @@ A subschema for constraints that may be placed on a given QEdge. ALL edges bound
 | qualifiers | Array\[[QualifierSetConstraint](#qualifiersetconstraint-)\] | **Minimum items: 1** A list of QualifierSetConstraints applied to a QEdge. If multiple QualifierSetConstraints are provided, there is an OR relationship between them. If the QEdge has multiple predicates or if the QNodes that correspond to the subject or object of this QEdge have multiple categories or multiple curies, then constraints.qualifiers MUST NOT be specified because these complex use cases are not supported at this time. |
 | sources | [AllowDenyConstraint](#allowdenyconstraint-) \| `object` | A list of infores CURIEs which are either allowed or denied in the sources (resource_id) of the bound Edge. If `behavior` is set to "ALLOW", ANY (at least 1) of the given infores CURIEs MUST be present. If `behavior` is set to "DENY", then ALL given infores CURIEs MUST NOT be present. |
 
-#### AllowDenyConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1057:L1080)
+#### AllowDenyConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1057:L1080)
 
 A list of values which are to either be allowed or denied. If `behavior` is set to "ALLOW", then ANY (at least 1) of the given values MUST appear in the constrained property in order for it to meet the constraint (OR relationship). If `behavior` is set to "DENY", then ALL of the given values MUST NOT appear in the constrained property in order for it to meet the constraint (NOT (x OR y) relationship).
 ##### Fixed Fields
@@ -244,7 +244,7 @@ A list of values which are to either be allowed or denied. If `behavior` is set 
 | behavior | `string` | **REQUIRED**.  |
 | values | Array\[`string`\] | **REQUIRED**. **Minimum items: 1**  |
 
-#### QPath [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1081:L1129)
+#### QPath [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1081:L1129)
 
 A path in the QueryGraph used for pathfinder queries. Both subject and object MUST reference QNodes that have a CURIE in their ids field. Paths returned that bind to this QPath can represent some relationship between subject and object.
 ##### Fixed Fields
@@ -256,7 +256,7 @@ A path in the QueryGraph used for pathfinder queries. Both subject and object MU
 | predicates | Array\[[BiolinkPredicate](#biolinkpredicate-)\] | **Minimum items: 1** QPath predicates are intended to convey what type of paths are desired, NOT a constraint on the types of predicates that may be in result paths. If no predicate is listed, the ARA SHOULD find paths such that the relationship represented by the path is a "related_to" relationship. These should be Biolink Model predicates and are allowed to be of type 'abstract' or 'mixin' (only in QGraphs!). Use of 'deprecated' predicates should be avoided. |
 | constraints | Array\[[PathConstraint](#pathconstraint-)\] | **Minimum items: 1** A list of constraints for the QPath. If multiple constraints are listed, it should be interpreted as an OR relationship. Each path returned is required to comply with at least one constraint. |
 
-#### PathConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1130:L1146)
+#### PathConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1130:L1146)
 
 A constraint for paths. ARAs must comply with constraints when finding paths.
 ##### Fixed Fields
@@ -265,7 +265,7 @@ A constraint for paths. ARAs must comply with constraints when finding paths.
 | --- | :---: | --- |
 | intermediate_categories | Array\[[BiolinkEntity](#biolinkentity-)\] | **Minimum items: 1** A list of Biolink model categories by which to constrain paths returned. If multiple categories are listed, it should be interpreted as an AND relationship. Each path returned by ARAs MUST contain at least one node of each category listed. |
 
-#### Node [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1147:L1181)
+#### Node [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1147:L1181)
 
 A node in the KnowledgeGraph which represents some biomedical concept. Nodes are identified by the keys in the KnowledgeGraph Node mapping.
 ##### Fixed Fields
@@ -277,7 +277,7 @@ A node in the KnowledgeGraph which represents some biomedical concept. Nodes are
 | attributes | Array\[[Attribute](#attribute-)\] | A list of attributes describing the node |
 | is_set | `boolean` | Indicates that the node represents a set of entities. If this property is missing or null, it is assumed to be false. |
 
-#### Attribute [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1182:L1267)
+#### Attribute [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1182:L1267)
 
 Generic attribute for a node or an edge that expands the key-value pair concept by including fields for additional metadata. These fields can be used to describe the source of the statement made in a key-value pair of the attribute object, or describe the attribute's value itself including its semantic type, or a url providing additional information about it. An attribute may be further qualified with sub-attributes (for example to provide confidence intervals on a value).
 ##### Fixed Fields
@@ -293,7 +293,7 @@ Generic attribute for a node or an edge that expands the key-value pair concept 
 | description | `string` | Human-readable description for the attribute and its value. |
 | attributes | Array\[[Attribute](#attribute-)\] | A list of attributes providing further information about the parent attribute (for example to provide provenance information about the parent attribute). |
 
-#### Edge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1268:L1350)
+#### Edge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1268:L1350)
 
 A specification of the semantic relationship linking two concepts that are expressed as nodes in the knowledge "thought" graph resulting from a query upon the underlying knowledge source.
 ##### Fixed Fields
@@ -309,7 +309,7 @@ A specification of the semantic relationship linking two concepts that are expre
 | knowledge_level | `string` | **REQUIRED**. One of the biolink-enumerated permissible values for `knowledge level` that provides the level of knowledge the Edge represents. (See https://biolink.github.io/biolink-model/KnowledgeLevelEnum/) |
 | agent_type | `string` | **REQUIRED**. One of the biolink-enumerated permissible values for `agent type` that provides the kind of agent which originated the knowledge presented by the Edge. (See https://biolink.github.io/biolink-model/AgentTypeEnum/) |
 
-#### Qualifier [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1351:L1387)
+#### Qualifier [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1351:L1387)
 
 An additional nuance attached to an assertion
 ##### Fixed Fields
@@ -319,7 +319,7 @@ An additional nuance attached to an assertion
 | qualifier_type_id | [CURIE](#curie-) | **REQUIRED**. CURIE for a Biolink 'qualifier' association slot, generally taken from Biolink association slots designated for this purpose (that is, association slots with names ending in 'qualifier') e.g. biolink:subject_aspect_qualifier, biolink:subject_direction_qualifier, biolink:object_aspect_qualifier, etc. Such qualifiers are used to elaborate a second layer of meaning of a knowledge graph edge. Available qualifiers are edge properties in the Biolink Model (see https://biolink.github.io/biolink-model/docs/edge_properties.html) which have slot names with the suffix string 'qualifier'. |
 | qualifier_value | `string` | **REQUIRED**. The value associated with the type of the qualifier, drawn from a set of controlled values by the type as specified in the Biolink model (e.g. 'expression' or 'abundance' for the qualifier type 'biolink:subject_aspect_qualifier', etc). The enumeration of qualifier values for a given qualifier type is generally going to be constrained by the category of edge (i.e. biolink:Association subtype) of the (Q)Edge. |
 
-#### QualifierSetConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1388:L1403)
+#### QualifierSetConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1388:L1403)
 
 A constraint on the qualifiers of a bound Edge (types and values). A given key-value pair defines the required qualifier_type_id and qualifier_value of one Qualifier, respectively. For example, a QualifierSetConstraint can constrain a "ChemicalX - affects - ?Gene" query to return only edges where ChemicalX specifically affects the 'expression' of the Gene, by constraining on the qualifier_type "biolink:object_aspect_qualifier" with a qualifier_value of "expression". Multiple type-value pairs have an AND relationship.
 
@@ -329,19 +329,19 @@ A constraint on the qualifiers of a bound Edge (types and values). A given key-v
 | --- | :---: | --- |
 | ^biolink: | `string` |  |
 
-#### BiolinkEntity [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1404:L1415)
+#### BiolinkEntity [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1404:L1415)
 
 Compact URI (CURIE) for a Biolink class, biolink:NamedThing or a child thereof. The CURIE must use the prefix 'biolink:' followed by the PascalCase class name.
 `string` (pattern: `^biolink:[A-Z][a-zA-Z]*$`)
-#### BiolinkPredicate [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1416:L1428)
+#### BiolinkPredicate [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1416:L1428)
 
 CURIE for a Biolink 'predicate' slot, taken from the Biolink slot ('is_a') hierarchy rooted in biolink:related_to (snake_case). This predicate defines the Biolink relationship between the subject and object nodes of a biolink:Association defining a knowledge graph edge.
 `string` (pattern: `^biolink:[a-z][a-z_]*$`)
-#### CURIE [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1429:L1438)
+#### CURIE [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1429:L1438)
 
 A Compact URI, consisting of a prefix and a reference separated by a colon, such as UniProtKB:P00738. Via an external context definition, the CURIE prefix and colon may be replaced by a URI prefix, such as http://identifiers.org/uniprot/, to form a full URI.
 `string`
-#### MetaKnowledgeGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1439:L1466)
+#### MetaKnowledgeGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1439:L1466)
 
 Knowledge-map representation of this TRAPI web service. The meta knowledge graph is composed of the union of most specific categories and predicates for each node and edge.
 ##### Fixed Fields
@@ -351,7 +351,7 @@ Knowledge-map representation of this TRAPI web service. The meta knowledge graph
 | nodes | Map\[`string`, [MetaNode](#metanode-)\] | **REQUIRED**. **Minimum properties: 1** Collection of the most specific node categories provided by this TRAPI web service, indexed by Biolink class CURIEs. A node category is only exposed here if there is node for which that is the most specific category available. |
 | edges | Array\[[MetaEdge](#metaedge-)\] | **REQUIRED**. List of the most specific edges/predicates provided by this TRAPI web service. A predicate is only exposed here if there is an edge for which the predicate is the most specific available. |
 
-#### MetaNode [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1467:L1490)
+#### MetaNode [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1467:L1490)
 
 Description of a node category provided by this TRAPI web service.
 ##### Fixed Fields
@@ -361,7 +361,7 @@ Description of a node category provided by this TRAPI web service.
 | id_prefixes | Array\[`string`\] | **REQUIRED**. **Minimum items: 1** List of CURIE prefixes for the node category that this TRAPI web service understands and accepts on the input. |
 | attributes | Array\[[MetaAttribute](#metaattribute-)\] | Node attributes provided by this TRAPI web service. |
 
-#### MetaEdge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1491:L1555)
+#### MetaEdge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1491:L1555)
 
 Edge in a meta knowledge map describing relationship between a subject Biolink class and an object Biolink class.
 ##### Fixed Fields
@@ -376,7 +376,7 @@ Edge in a meta knowledge map describing relationship between a subject Biolink c
 | qualifiers | Array\[[MetaQualifier](#metaqualifier-)\] | **Minimum items: 1** Qualifiers that are possible to be found on this edge type. |
 | association | [BiolinkEntity](#biolinkentity-) | The Biolink association type (entity) that this edge represents. Associations are classes in Biolink that represent a relationship between two entities. For example, the association 'gene interacts with gene' is represented by the Biolink class, 'biolink:GeneToGeneAssociation'.  If association is filled out, then the testing harness can help validate that the qualifiers are being used correctly. |
 
-#### MetaQualifier [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1556:L1575)
+#### MetaQualifier [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1556:L1575)
 
 ##### Fixed Fields
 
@@ -385,7 +385,7 @@ Edge in a meta knowledge map describing relationship between a subject Biolink c
 | qualifier_type_id | [CURIE](#curie-) | **REQUIRED**. The CURIE of the qualifier type. |
 | applicable_values | Array\[`string`\] | **Minimum items: 1** The list of values that are possible for this qualifier. |
 
-#### MetaAttribute [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1576:L1613)
+#### MetaAttribute [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1576:L1613)
 
 ##### Fixed Fields
 
@@ -397,7 +397,7 @@ Edge in a meta knowledge map describing relationship between a subject Biolink c
 | constraint_use | `boolean` | Indicates whether this attribute can be used as a query constraint. |
 | constraint_name | `string` | Human-readable name or label for the constraint concept. Required whenever constraint_use is true. |
 
-#### AttributeConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1614:L1707)
+#### AttributeConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1614:L1707)
 
 Generic query constraint for a query node or query edge
 ##### Fixed Fields
@@ -412,7 +412,7 @@ Generic query constraint for a query node or query edge
 | unit_id | any | CURIE of the units of the value or list of values in the 'value' property. The Units of Measurement Ontology (UO) should be used if possible. The unit_id MUST be provided for (lists of) numerical values that correspond to a quantity that has units. |
 | unit_name | any | Term name that is associated with the CURIE of the units of the value or list of values in the 'value' property. The Units of Measurement Ontology (UO) SHOULD be used if possible. This property SHOULD be provided if a unit_id is provided. This is redundant but recommended for human readability. |
 
-#### RetrievalSource [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1708:L1765)
+#### RetrievalSource [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1708:L1765)
 
 Provides information about how a particular InformationResource served as a source from which knowledge expressed in an Edge, or data used to generate this knowledge, was retrieved.
 ##### Fixed Fields
@@ -424,7 +424,7 @@ Provides information about how a particular InformationResource served as a sour
 | upstream_resource_ids | Array\[[CURIE](#curie-)\] | **Minimum items: 1** An upstream InformationResource from which the resource being described directly retrieved a record of the knowledge expressed in the Edge, or data used to generate this knowledge. This is an array because there are cases where a merged Edge holds knowledge that was retrieved from multiple sources. e.g. an Edge provided by the ARAGORN ARA can expressing knowledge it retrieved from both the automat-mychem-info and molepro KPs, which both provided it with records of this single fact. |
 | source_record_urls | Array\[`string`\] | **Minimum items: 1** A URL linking to a specific web page or document provided by the source, that contains a record of the knowledge expressed in the Edge. If the knowledge is contained in more than one web page on an Information Resource's site, urls MAY be provided for each. For example, Therapeutic Targets Database (TTD) has separate web pages for 'Imatinib' and its protein target KIT, both of which hold the claim that 'the KIT protein is a therapeutic target for Imatinib'. |
 
-#### ResourceRoleEnum [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1766:L1777)
+#### ResourceRoleEnum [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/edeutsch-changelog/TranslatorReasonerAPI.yaml#L1766:L1777)
 
 The role played by the InformationResource in serving as a source for an Edge. Note that a given Edge should have one and only one 'primary' source, and may have any number of 'aggregator' or 'supporting data' sources.  This enumeration is found in Biolink Model, but is repeated here for convenience.
 `string`


### PR DESCRIPTION
Updated ChangeLog to reflect changes from TRAPI 1.4.0 to 1.6.0-beta, including migration to OpenAPI 3.1.2 and various property adjustments.