### PR TITLE
update change/migration/spec docs, Lint fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# Change Log  2.0.0-beta (2026-04-02) -> 2.0.0 (TBD)
+
+- Make AttributeConstraint.name optional, adjust descriptions in AttributeConstraint and Attribute specs ([PR](https://github.com/NCATSTranslator/ReasonerAPI/pull/563/changes))
+
+
 # Change Log  1.6.0-beta (2025-06-06) -> 2.0.0-beta (2026-04-02)
 
 ### 1. QEdge Constraints Refactor (see [migration guide entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md#1-qedge-constraints-refactor), [reference doc entry](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/docs/reference.md#qedge-))

--- a/ImplementationGuidance/DataExamples/2-0_example_response.json
+++ b/ImplementationGuidance/DataExamples/2-0_example_response.json
@@ -61,7 +61,6 @@
             "attributes": [
               {
                 "id": "biolink:z_score",
-                "name": "z-score",
                 "operator": ">",
                 "value": 5
               }

--- a/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md
+++ b/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide2-0.md
@@ -69,7 +69,7 @@ In 2.0, there is instead one property on a QEdge, `constraints`, that holds all 
 * `agent_type`: see above (KL)
    * FYI: if a specified value has descendants (ex: `automated_agent`), the tool MUST treat those descendants (ex: `text_mining_agent`, etc.) as if they were included in the `values` array (i.e. "hierarchy expansion").
 * `sources`: this constrains the Edge `sources`. It has the same keys as KL/AT (`behavior`, `values`) plus the optional `primary_only` (if true, the constraint ONLY applies to the `primary_knowledge_source`). 
-* `attributes`: minItems 1, otherwise the same as previous `attribute_constraints`
+* `attributes`: minItems 1 and `name` no longer required, otherwise the same as previous `attribute_constraints`
 * `qualifiers`: simplified format to an array of objects but preserved previous behavior. Each object represents a qualifier-set, and multiple objects/sets have an `OR` relationship. Within an object, the keys are the "qualifier-type-ids" and their values are the "qualifier values". Multiple key/value pairs in one object/set have an `AND` relationship. 
 
 **NOTE on SUBCLASSING**: we haven't decided yet how QEdge constraints work with subclassing. For now, QEdge constraints should only apply to the bound Edges (constructed in subclassing cases), NOT to the bound Edge's support_graph edges. QNode constraints also has this ambiguity/confusion with subclassing. 
@@ -93,7 +93,6 @@ In 2.0, there is instead one property on a QEdge, `constraints`, that holds all 
         "attributes": [
             {
                 "id": "biolink:z_score",    // regular attribute constraint
-                "name": "z-score",
                 "operator": ">",
                 "value": 5
             }
@@ -448,6 +447,7 @@ It was previously required, but never used and its empty arrays bloated response
 
 These properties were changed to not required:
 * `Nodes.attributes`
+* `AttributeConstraint.name` ([PR](https://github.com/NCATSTranslator/ReasonerAPI/pull/563/changes))
 * `QueryGraph` `edges` and `paths`: to accommodate queries with only nodes
 * `KnowledgeGraph.edges`: same reason as above
 * `Result.analyses`: same reason as above

--- a/ImplementationGuidance/Specifications/qedge_constraints_specification.md
+++ b/ImplementationGuidance/Specifications/qedge_constraints_specification.md
@@ -109,9 +109,8 @@ The matched Edge's `primary_knowledge_source` should NOT be `infores:semmeddb` o
 
 Attribute constraints are presented as a list of attribute constraint objects. Each attribute constraint object constrains a specific attribute type. Multiple attribute constraints together represent an AND relationship, such that all attribute constraints must be met.
 
-Every attribute constraint must supply a `name`, `id`, `value`, and `operator`:
+Every attribute constraint must supply a `id`, `value`, and `operator`:
 
-- `name`: For human use, this just specifies the intent of the constraint.
 - `id`: This targets the constraint to attributes with a specific `attribute_type_id`.
 - `value`: Provides a value with which the targeted attribute must agree.
 - `operator`: Provides the relationship to the `value` that targeted attributes must fulfill.
@@ -124,7 +123,6 @@ In the most simple case, the operator `===` requires that edges must have an att
 
 ```json
 {
-    "name": "Must have the exact given publication list",
     "id": "biolink:publications",
     "operator": "===",
     "value": ["PMID:1234", "PMID:4567"]
@@ -205,7 +203,6 @@ The only operator for which this behavior is not held is `===` (strict equality)
         "attributes": [
             {
                 "id": "biolink:z_score",    // regular attribute constraint
-                "name": "z-score",
                 "operator": ">",
                 "value": 5
             }

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1630,8 +1630,8 @@ components:
           description: >-
             Human-readable name or label for the constraint concept.
             It SHOULD be the term name of the CURIE used
-            as the 'id' and SHOULD NOT supersede the use of AttributeConstraint.id (which
-            is required). This is redundant but recommended for human
+            as the 'id' and SHOULD NOT supersede the use of AttributeConstraint.id 
+            (which is required). This is redundant but recommended for human
             readability.
           examples:
             - molecular mass

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,7 +2,7 @@
 
 ## Components
 
-#### Query [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L277:L315)
+#### Query [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L277:L315)
 
 The Query class is used to package a user request for information. A Query object consists of a required Message object with optional additional properties. Additional properties are intended to convey implementation-specific or query-independent parameters. For example, an additional property specifying a log level could allow a user to override the default log level in order to receive more fine-grained log information when debugging an issue.
 ##### Fixed Fields
@@ -14,7 +14,7 @@ The Query class is used to package a user request for information. A Query objec
 | message | [Message](#message-) | **REQUIRED**. The query Message is a serialization of the user request. Content of the Message object depends on the intended TRAPI operation. For example, the fill operation requires a non-empty query_graph property as part of the Message, whereas other operations, e.g. overlay, require non-empty results and knowledge_graph properties. |
 | workflow | [workflow](#workflow-) | List of workflow steps to be executed. |
 
-#### AsyncQuery [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L316:L339)
+#### AsyncQuery [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L316:L339)
 
 The AsyncQuery class is effectively the same as the Query class but it requires a callback property.
 
@@ -27,7 +27,7 @@ The AsyncQuery class is effectively the same as the Query class but it requires 
 | --- | :---: | --- |
 | callback | `string` | **REQUIRED**. Upon completion, this server will send a POST request to the callback URL with `Content-Type: application/json` header and request body containing a JSON-encoded `Response` object. The server MAY POST `Response` objects before work is fully complete to provide interim results with a Response.status value of 'Running'. If a POST operation to the callback URL does not succeed, the server SHOULD retry the POST at least once. |
 
-#### QueryParameters [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L340:L371)
+#### QueryParameters [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L340:L371)
 
 Query-time parameters that don't affect the semantics of a query or intended workflow, but may affect overall behavior of the server in the execution of this query. The server MUST maintain parameters it is given in the response.
 ##### Fixed Fields
@@ -38,7 +38,7 @@ Query-time parameters that don't affect the semantics of a query or intended wor
 | log_level | [LogLevel](#loglevel-) | The least critical level of logs to return. |
 | bypass_cache | `boolean` | Set to true in order to request that the agent obtain fresh information from its sources in all cases where it has a viable choice between requesting fresh information in real time and using cached information. The agent receiving this flag MUST also include it in TRAPI sent to downstream sources (e.g., ARS -> ARAs -> KPs). |
 
-#### AsyncQueryResponse [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L372:L402)
+#### AsyncQueryResponse [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L372:L402)
 
 The AsyncQueryResponse object contains a payload that must be returned from a submitted async_query.
 ##### Fixed Fields
@@ -49,7 +49,7 @@ The AsyncQueryResponse object contains a payload that must be returned from a su
 | description | `string` | A brief human-readable description of the result of the async_query submission. |
 | job_id | `string` | **REQUIRED**. An identifier for the submitted job that can be used with /async_query_status to receive an update on the status of the job. |
 
-#### AsyncQueryStatusResponse [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L403:L445)
+#### AsyncQueryStatusResponse [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L403:L445)
 
 The AsyncQueryStatusResponse object contains a payload that describes the current status of a previously submitted async_query.
 ##### Fixed Fields
@@ -61,7 +61,7 @@ The AsyncQueryStatusResponse object contains a payload that describes the curren
 | logs | Array\[[LogEntry](#logentry-)\] | **REQUIRED**. **Minimum items: 1.** A list of LogEntry items, containing errors, warnings, debugging information, etc. List items MUST be in chronological order with earliest first. The most recent entry should be last. Its timestamp will be compared against the current time to see if there is still activity. |
 | response_url | `string` | Optional URL that can be queried to restrieve the full TRAPI Response. |
 
-#### Response [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L446:L502)
+#### Response [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L446:L502)
 
 The Response object contains the main payload when a TRAPI query endpoint interprets and responds to the submitted query successfully (i.e., HTTP Status Code 200). The message property contains the knowledge of the response (query graph, knowledge graph, and results). The status, description, and logs properties provide additional details about the response.
 ##### Fixed Fields
@@ -77,7 +77,7 @@ The Response object contains the main payload when a TRAPI query endpoint interp
 | schema_version | `string` | Version label of the TRAPI schema used in this document |
 | biolink_version | `string` | Version label of the Biolink model used in this document |
 
-#### Message [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L503:L546)
+#### Message [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L503:L546)
 
 The message object holds the main content of a Query or a Response in three properties: query_graph, results, and knowledge_graph. The query_graph property contains the query configuration, the results property contains any answers that are returned by the service, and knowledge_graph property contains lists of edges and nodes in the thought graph corresponding to this message. The content of these properties is context-dependent to the encompassing object and the TRAPI operation requested.
 ##### Fixed Fields
@@ -89,7 +89,7 @@ The message object holds the main content of a Query or a Response in three prop
 | knowledge_graph | [KnowledgeGraph](#knowledgegraph-) | KnowledgeGraph object that contains lists of nodes and edges in the thought graph corresponding to the message |
 | auxiliary_graphs | Map\[`string`, [AuxiliaryGraph](#auxiliarygraph-)\] | **Minimum properties: 1.** Dictionary of AuxiliaryGraph instances that are used by Knowledge Graph Edges and Result Analyses. These are referenced elsewhere by the dictionary key. |
 
-#### LogEntry [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L547:L584)
+#### LogEntry [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L547:L584)
 
 The LogEntry object contains information useful for tracing and debugging across Translator components.  Although an individual component (for example, an ARA or KP) may have its own logging and debugging infrastructure, this internal information is not, in general, available to other components. In addition to a timestamp and logging level, LogEntry includes a string intended to be read by a human, along with one of a standardized set of codes describing the condition of the component sending the message.
 ##### Fixed Fields
@@ -101,7 +101,7 @@ The LogEntry object contains information useful for tracing and debugging across
 | code | `string` | One of a standardized set of short codes e.g. QueryNotTraversable, KPNotAvailable, KPResponseMalformed |
 | message | `string` | **REQUIRED**. A human-readable log message |
 
-#### LogLevel [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L585:L592)
+#### LogLevel [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L585:L592)
 
 Logging level
 `string`
@@ -113,7 +113,7 @@ one of:
 - INFO
 - DEBUG
 
-#### Result [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L593:L623)
+#### Result [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L593:L623)
 
 A Result object specifies the nodes and edges in the knowledge graph that satisfy the structure or conditions of a user-submitted query graph. It must contain a NodeBindings object (list of query graph node to knowledge graph node mappings) and a list of Analysis objects.
 ##### Fixed Fields
@@ -123,7 +123,7 @@ A Result object specifies the nodes and edges in the knowledge graph that satisf
 | node_bindings | Map\[`string`, [NodeBinding](#nodebinding-)\] | **REQUIRED**. **Minimum properties: 1.** The dictionary of Input Query Graph to Result Knowledge Graph node bindings where the dictionary keys are the key identifiers of the Query Graph nodes and the associated values of those keys are instances of NodeBinding schema type (see below). Because a given QNode may have multiple knowledge Nodes bound in the result, the NodeBinding object may list multiple knowledge Nodes. |
 | analyses | Array\[[Analysis](#analysis-)\] | **Minimum items: 1.** The list of all Analysis components that contribute to the result. See below for Analysis components. |
 
-#### NodeBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L624:L643)
+#### NodeBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L624:L643)
 
 A NodeBinding object defines all relevant KnowledgeGraph Node mappings, identified by the corresponding object key identifier(s) of the Node(s) within the Knowledge Graph. Instances of NodeBinding may include extra annotation in the form of additional properties. (such annotation is not yet fully standardized). Each Node Binding must bind directly to node in the original Query Graph.
 ##### Fixed Fields
@@ -132,7 +132,7 @@ A NodeBinding object defines all relevant KnowledgeGraph Node mappings, identifi
 | --- | :---: | --- |
 | ids | Array\[[CURIE](#curie-)\] | **REQUIRED**. **Minimum items: 1.** The CURIEs of one or more Nodes within the Knowledge Graph. |
 
-#### Analysis [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L644:L713)
+#### Analysis [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L644:L713)
 
 An analysis is a dictionary that contains information about the result tied to a particular service. Each Analysis is generated by a single reasoning service, and describes the outputs of analyses performed by the reasoner on a particular Result (e.g. a result score), along with provenance information supporting the analysis (e.g. method or data that supported generation of the score).
 ##### Fixed Fields
@@ -147,7 +147,7 @@ An analysis is a dictionary that contains information about the result tied to a
 | scoring_method | `string` | An identifier and link to an explanation for the method used to generate the score |
 | attributes | Array\[[Attribute](#attribute-)\] | The attributes of this particular Analysis. |
 
-#### EdgeBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L714:L733)
+#### EdgeBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L714:L733)
 
 An EdgeBinding object defines all relevant KnowledgeGraph Edge mappings, identified by the corresponding 'id' object key identifier of the Edge within the Knowledge Graph. Instances of EdgeBinding may include extra annotation (such annotation is not yet fully standardized). Edge bindings are captured within a specific reasoner's Analysis object because the Edges in the Knowledge Graph that get bound to the input Query Graph may differ between reasoners.
 ##### Fixed Fields
@@ -156,7 +156,7 @@ An EdgeBinding object defines all relevant KnowledgeGraph Edge mappings, identif
 | --- | :---: | --- |
 | ids | Array\[`string`\] | **REQUIRED**. **Minimum items: 1.** The key identifiers of specific KnowledgeGraph Edges. |
 
-#### PathBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L734:L750)
+#### PathBinding [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L734:L750)
 
 A PathBinding object binds a single QueryGraph path (the key to this object) to one or more relevant AuxiliaryGraph ids containing a list of edges in the path. The Auxiliary Graph does not convey any order of edges in the path.
 ##### Fixed Fields
@@ -165,7 +165,7 @@ A PathBinding object binds a single QueryGraph path (the key to this object) to 
 | --- | :---: | --- |
 | ids | Array\[`string`\] | **REQUIRED**. **Minimum items: 1.** The key identifiers of specific auxiliary graphs. |
 
-#### AuxiliaryGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L751:L776)
+#### AuxiliaryGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L751:L776)
 
 A single AuxiliaryGraph instance that is used by Knowledge Graph Edges, Result Analysis support graphs, and Path Bindings. Edges comprising an Auxiliary Graph are a subset of the Knowledge Graph in the message. Data creators can create an AuxiliaryGraph to assemble a specific collection of edges from the Knowledge Graph into a named graph that can be referenced from an Edge as evidence/explanation supporting that Edge, from a Result Analysis as information used to generate a score, or from a Path Binding as the path for that Analysis.
 ##### Fixed Fields
@@ -174,7 +174,7 @@ A single AuxiliaryGraph instance that is used by Knowledge Graph Edges, Result A
 | --- | :---: | --- |
 | edges | Array\[`string`\] | **REQUIRED**. **Minimum items: 1.** List of edges that form the Auxiliary Graph. Each item is a reference to a single Knowledge Graph Edge. This list is not ordered, nor is the order intended to convey any relationship between the edges that form this Auxiliary Graph. |
 
-#### KnowledgeGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L777:L803)
+#### KnowledgeGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L777:L803)
 
 The knowledge graph associated with a set of results. The instances of Node and Edge defining this graph represent instances of biolink:NamedThing (concept nodes) and biolink:Association (relationship edges) representing (Attribute) annotated knowledge returned from the knowledge sources and inference agents wrapped by the given TRAPI implementation.
 ##### Fixed Fields
@@ -184,7 +184,7 @@ The knowledge graph associated with a set of results. The instances of Node and 
 | nodes | Map\[`string`, [Node](#node-)\] | **REQUIRED**. Dictionary of Node instances used in the KnowledgeGraph, referenced elsewhere in the TRAPI output by the dictionary key. |
 | edges | Map\[`string`, [Edge](#edge-)\] | Dictionary of Edge instances used in the KnowledgeGraph, referenced elsewhere in the TRAPI output by the dictionary key. |
 
-#### QueryGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L804:L844)
+#### QueryGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L804:L844)
 
 A graph representing a biomedical question. It serves as a template for each result (answer), where each bound knowledge graph node/edge is expected to obey the constraints of the associated query graph element.
 ##### Fixed Fields
@@ -195,7 +195,7 @@ A graph representing a biomedical question. It serves as a template for each res
 | edges | Map\[`string`, [QEdge](#qedge-)\] | **Minimum properties: 1.** The edge specifications. The keys of this map are unique edge identifiers and the corresponding values include the constraints on bound edges, in addition to specifying the subject and object QNodes. |
 | paths | Map\[`string`, [QPath](#qpath-)\] | **Minimum properties: 1.** The QueryGraph path specification, used only for pathfinder type queries. The keys of this map are unique path identifiers and the corresponding values include the constraints on bound paths, in addition to specifying the subject, object, and intermediate QNodes. |
 
-#### QNode [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L845:L920)
+#### QNode [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L845:L920)
 
 A node in the QueryGraph used to represent an entity in a query. If a CURIE is not specified, any nodes matching the category of the QNode will be returned in the Results.
 ##### Fixed Fields
@@ -208,7 +208,7 @@ A node in the QueryGraph used to represent an entity in a query. If a CURIE is n
 | member_ids | Array\[[CURIE](#curie-)\] | **Minimum items: 1.** A list of CURIE identifiers for members of a queried set. This property MUST be populated under a set_interpretation of MANY or ALL, when the 'ids' property holds a UUID representing the set itself. This property MUST NOT be used under a set_interpretation of BATCH or COLLATE or when set_interpretation is absent. |
 | constraints | Array\[[AttributeConstraint](#attributeconstraint-)\] | **Minimum items: 1.** A list of constraints applied to a query node. If there are multiple items, they must all be true (equivalent to AND) |
 
-#### QEdge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L921:L981)
+#### QEdge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L921:L981)
 
 An edge in the QueryGraph used as a filter pattern specification in a query. If the optional predicate property is not specified, it is assumed to be a wildcard match to the target knowledge space. If specified, the ontological inheritance hierarchy associated with the term provided is assumed, such that edge bindings returned may be an exact match to the given QEdge predicate term, or to a term that is a descendant of the QEdge predicate term.
 ##### Fixed Fields
@@ -221,7 +221,7 @@ An edge in the QueryGraph used as a filter pattern specification in a query. If 
 | object | `string` | **REQUIRED**. Corresponds to the map key identifier of the object concept node anchoring the query filter pattern for the query relationship edge. |
 | constraints | [QEdgeConstraints](#qedgeconstraints-) | An object containing all constraints placed on the QEdge. ALL edges bound to this QEdge MUST conform to ALL given constraints; underlying edges (such as those appearing in supporting graphs) are not required to conform to the given constraints. |
 
-#### QEdgeConstraints [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L982:L1056)
+#### QEdgeConstraints [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L982:L1056)
 
 A subschema for constraints that may be placed on a given QEdge. ALL edges bound to the given QEdge MUST conform to ALL given constraints; underlying edges (such as those appearing in supporting graphs) are not required to conform to the given constraints.
 ##### Fixed Fields
@@ -234,7 +234,7 @@ A subschema for constraints that may be placed on a given QEdge. ALL edges bound
 | qualifiers | Array\[[QualifierSetConstraint](#qualifiersetconstraint-)\] | **Minimum items: 1.** A list of QualifierSetConstraints applied to a QEdge. If multiple QualifierSetConstraints are provided, there is an OR relationship between them. If the QEdge has multiple predicates or if the QNodes that correspond to the subject or object of this QEdge have multiple categories or multiple curies, then constraints.qualifiers MUST NOT be specified because these complex use cases are not supported at this time. |
 | sources | [AllowDenyConstraint](#allowdenyconstraint-) \| `object` | A list of infores CURIEs which are either allowed or denied in the sources (resource_id) of the bound Edge. If `behavior` is set to "ALLOW", ANY (at least 1) of the given infores CURIEs MUST be present. If `behavior` is set to "DENY", then ALL given infores CURIEs MUST NOT be present. |
 
-#### AllowDenyConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1057:L1080)
+#### AllowDenyConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1057:L1080)
 
 A list of values which are to either be allowed or denied. If `behavior` is set to "ALLOW", then ANY (at least 1) of the given values MUST appear in the constrained property in order for it to meet the constraint (OR relationship). If `behavior` is set to "DENY", then ALL of the given values MUST NOT appear in the constrained property in order for it to meet the constraint (NOT (x OR y) relationship).
 ##### Fixed Fields
@@ -244,7 +244,7 @@ A list of values which are to either be allowed or denied. If `behavior` is set 
 | behavior | `string` | **REQUIRED**.  |
 | values | Array\[`string`\] | **REQUIRED**. **Minimum items: 1.**  |
 
-#### QPath [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1081:L1129)
+#### QPath [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1081:L1129)
 
 A path in the QueryGraph used for pathfinder queries. Both subject and object MUST reference QNodes that have a CURIE in their ids property. Paths returned that bind to this QPath can represent some relationship between subject and object.
 ##### Fixed Fields
@@ -256,7 +256,7 @@ A path in the QueryGraph used for pathfinder queries. Both subject and object MU
 | predicates | Array\[[BiolinkPredicate](#biolinkpredicate-)\] | **Minimum items: 1.** QPath predicates are intended to convey what type of paths are desired, NOT a constraint on the types of predicates that may be in result paths. If no predicate is listed, the ARA SHOULD find paths such that the relationship represented by the path is a "related_to" relationship. These should be Biolink Model predicates and are allowed to be of type 'abstract' or 'mixin' (only in QGraphs!). Use of 'deprecated' predicates should be avoided. |
 | constraints | Array\[[PathConstraint](#pathconstraint-)\] | **Minimum items: 1.** A list of constraints for the QPath. If multiple constraints are listed, it should be interpreted as an OR relationship. Each path returned is required to comply with at least one constraint. |
 
-#### PathConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1130:L1146)
+#### PathConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1130:L1146)
 
 A constraint for paths. ARAs must comply with constraints when finding paths.
 ##### Fixed Fields
@@ -265,7 +265,7 @@ A constraint for paths. ARAs must comply with constraints when finding paths.
 | --- | :---: | --- |
 | intermediate_categories | Array\[[BiolinkEntity](#biolinkentity-)\] | **Minimum items: 1.** A list of Biolink model categories by which to constrain paths returned. If multiple categories are listed, it should be interpreted as an AND relationship. Each path returned by ARAs MUST contain at least one node of each category listed. |
 
-#### Node [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1147:L1181)
+#### Node [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1147:L1181)
 
 A node in the KnowledgeGraph which represents some biomedical concept. Nodes are identified by the keys in the KnowledgeGraph Node mapping.
 ##### Fixed Fields
@@ -277,7 +277,7 @@ A node in the KnowledgeGraph which represents some biomedical concept. Nodes are
 | attributes | Array\[[Attribute](#attribute-)\] | A list of attributes describing the node |
 | is_set | `boolean` | Indicates that the node represents a set of entities. If this property is absent, it is assumed to be false. |
 
-#### Attribute [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1182:L1265)
+#### Attribute [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1182:L1265)
 
 Generic attribute for a node or an edge that expands the key-value pair concept by including properties for additional metadata. These properties can be used to describe the source of the statement made in a key-value pair of the attribute object, or describe the attribute's value itself including its semantic type, or a url providing additional information about it. An attribute may be further qualified with sub-attributes (for example to provide confidence intervals on a value).
 ##### Fixed Fields
@@ -293,7 +293,7 @@ Generic attribute for a node or an edge that expands the key-value pair concept 
 | description | `string` | Human-readable description for the attribute and its value. |
 | attributes | Array\[[Attribute](#attribute-)\] | A list of attributes providing further information about the parent attribute (for example to provide provenance information about the parent attribute). |
 
-#### Edge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1266:L1348)
+#### Edge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1266:L1348)
 
 A specification of the semantic relationship linking two concepts that are expressed as nodes in the knowledge "thought" graph resulting from a query upon the underlying knowledge source.
 ##### Fixed Fields
@@ -309,7 +309,7 @@ A specification of the semantic relationship linking two concepts that are expre
 | knowledge_level | `string` | **REQUIRED**. One of the biolink-enumerated permissible values for `knowledge level` that provides the level of knowledge the Edge represents. (See https://biolink.github.io/biolink-model/KnowledgeLevelEnum/) |
 | agent_type | `string` | **REQUIRED**. One of the biolink-enumerated permissible values for `agent type` that provides the kind of agent which originated the knowledge presented by the Edge. (See https://biolink.github.io/biolink-model/AgentTypeEnum/) |
 
-#### Qualifier [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1349:L1385)
+#### Qualifier [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1349:L1385)
 
 An additional nuance attached to an assertion
 ##### Fixed Fields
@@ -319,7 +319,7 @@ An additional nuance attached to an assertion
 | qualifier_type_id | [CURIE](#curie-) | **REQUIRED**. CURIE for a Biolink 'qualifier' association slot, generally taken from Biolink association slots designated for this purpose (that is, association slots with names ending in 'qualifier') e.g. biolink:subject_aspect_qualifier, biolink:subject_direction_qualifier, biolink:object_aspect_qualifier, etc. Such qualifiers are used to elaborate a second layer of meaning of a knowledge graph edge. Available qualifiers are edge properties in the Biolink Model (see https://biolink.github.io/biolink-model/docs/edge_properties.html) which have slot names with the suffix string 'qualifier'. |
 | qualifier_value | `string` | **REQUIRED**. The value associated with the type of the qualifier, drawn from a set of controlled values by the type as specified in the Biolink model (e.g. 'expression' or 'abundance' for the qualifier type 'biolink:subject_aspect_qualifier', etc). The enumeration of qualifier values for a given qualifier type is generally going to be constrained by the category of edge (i.e. biolink:Association subtype) of the (Q)Edge. |
 
-#### QualifierSetConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1386:L1401)
+#### QualifierSetConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1386:L1401)
 
 A constraint on the qualifiers of a bound Edge (types and values). A given key-value pair defines the required qualifier_type_id and qualifier_value of one Qualifier, respectively. For example, a QualifierSetConstraint can constrain a "ChemicalX - affects - ?Gene" query to return only edges where ChemicalX specifically affects the 'expression' of the Gene, by constraining on the qualifier_type "biolink:object_aspect_qualifier" with a qualifier_value of "expression". Multiple type-value pairs have an AND relationship.
 
@@ -329,19 +329,19 @@ A constraint on the qualifiers of a bound Edge (types and values). A given key-v
 | --- | :---: | --- |
 | ^biolink: | `string` |  |
 
-#### BiolinkEntity [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1402:L1413)
+#### BiolinkEntity [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1402:L1413)
 
 Compact URI (CURIE) for a Biolink class, biolink:NamedThing or a child thereof. The CURIE must use the prefix 'biolink:' followed by the PascalCase class name.
 `string` (pattern: `^biolink:[A-Z][a-zA-Z]*$`)
-#### BiolinkPredicate [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1414:L1426)
+#### BiolinkPredicate [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1414:L1426)
 
 CURIE for a Biolink 'predicate' slot, taken from the Biolink slot ('is_a') hierarchy rooted in biolink:related_to (snake_case). This predicate defines the Biolink relationship between the subject and object nodes of a biolink:Association defining a knowledge graph edge.
 `string` (pattern: `^biolink:[a-z][a-z_]*$`)
-#### CURIE [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1427:L1436)
+#### CURIE [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1427:L1436)
 
 A Compact URI, consisting of a prefix and a reference separated by a colon, such as UniProtKB:P00738. Via an external context definition, the CURIE prefix and colon may be replaced by a URI prefix, such as http://identifiers.org/uniprot/, to form a full URI.
 `string`
-#### MetaKnowledgeGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1437:L1464)
+#### MetaKnowledgeGraph [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1437:L1464)
 
 Knowledge-map representation of this TRAPI web service. The meta knowledge graph is composed of the union of most specific categories and predicates for each node and edge.
 ##### Fixed Fields
@@ -351,7 +351,7 @@ Knowledge-map representation of this TRAPI web service. The meta knowledge graph
 | nodes | Map\[`string`, [MetaNode](#metanode-)\] | **REQUIRED**. **Minimum properties: 1.** Collection of the most specific node categories provided by this TRAPI web service, indexed by Biolink class CURIEs. A node category is only exposed here if there is node for which that is the most specific category available. |
 | edges | Array\[[MetaEdge](#metaedge-)\] | **REQUIRED**. List of the most specific edges/predicates provided by this TRAPI web service. A predicate is only exposed here if there is an edge for which the predicate is the most specific available. |
 
-#### MetaNode [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1465:L1488)
+#### MetaNode [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1465:L1488)
 
 Description of a node category provided by this TRAPI web service.
 ##### Fixed Fields
@@ -361,7 +361,7 @@ Description of a node category provided by this TRAPI web service.
 | id_prefixes | Array\[`string`\] | **REQUIRED**. **Minimum items: 1.** List of CURIE prefixes for the node category that this TRAPI web service understands and accepts on the input. |
 | attributes | Array\[[MetaAttribute](#metaattribute-)\] | Node attributes provided by this TRAPI web service. |
 
-#### MetaEdge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1489:L1553)
+#### MetaEdge [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1489:L1553)
 
 Edge in a meta knowledge map describing relationship between a subject Biolink class and an object Biolink class.
 ##### Fixed Fields
@@ -376,7 +376,7 @@ Edge in a meta knowledge map describing relationship between a subject Biolink c
 | qualifiers | Array\[[MetaQualifier](#metaqualifier-)\] | **Minimum items: 1.** Qualifiers that are possible to be found on this edge type. |
 | association | [BiolinkEntity](#biolinkentity-) | The Biolink association type (entity) that this edge represents. Associations are classes in Biolink that represent a relationship between two entities. For example, the association 'gene interacts with gene' is represented by the Biolink class, 'biolink:GeneToGeneAssociation'.  If association is filled out, then the testing harness can help validate that the qualifiers are being used correctly. |
 
-#### MetaQualifier [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1554:L1573)
+#### MetaQualifier [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1554:L1573)
 
 ##### Fixed Fields
 
@@ -385,7 +385,7 @@ Edge in a meta knowledge map describing relationship between a subject Biolink c
 | qualifier_type_id | [CURIE](#curie-) | **REQUIRED**. The CURIE of the qualifier type. |
 | applicable_values | Array\[`string`\] | **Minimum items: 1.** The list of values that are possible for this qualifier. |
 
-#### MetaAttribute [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1574:L1611)
+#### MetaAttribute [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1574:L1611)
 
 ##### Fixed Fields
 
@@ -397,7 +397,7 @@ Edge in a meta knowledge map describing relationship between a subject Biolink c
 | constraint_use | `boolean` | Indicates whether this attribute can be used as a query constraint. |
 | constraint_name | `string` | Human-readable name or label for the constraint concept. Required whenever constraint_use is true. |
 
-#### AttributeConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1612:L1705)
+#### AttributeConstraint [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1612:L1705)
 
 Generic query constraint for a query node or query edge
 ##### Fixed Fields
@@ -405,14 +405,14 @@ Generic query constraint for a query node or query edge
 | Field Name | Type | Description |
 | --- | :---: | --- |
 | id | [CURIE](#curie-) | **REQUIRED**. CURIE of the concept being constrained. For properties defined by the Biolink model this SHOULD be a biolink CURIE. otherwise, if possible, from the EDAM ontology. If a suitable CURIE does not exist, enter a descriptive phrase here and submit the new type for consideration by the appropriate authority. |
-| name | `string` | Human-readable name or label for the constraint concept. It SHOULD be the term name of the CURIE used as the 'id' and SHOULD NOT supersede the use of AttributeConstraint.id (which is required). This is redundant but recommended for human readability. |
+| name | `string` | Human-readable name or label for the constraint concept. It SHOULD be the term name of the CURIE used as the 'id' and SHOULD NOT supersede the use of AttributeConstraint.id  (which is required). This is redundant but recommended for human readability. |
 | not | `boolean` |  |
 | operator | `string` | **REQUIRED**. Relationship between the database value and the constraint value for the specified id. The operators ==, >, and < mean is equal to, is greater than, and is less than, respectively. The 'matches' operator indicates that the value is a regular expression to be evaluated. If value is a list type, then at least one evaluation must be true (equivalent to OR). This means that the == operator with a list acts like a SQL 'IN' clause. If the value of the compared attribute is a list, then comparisons are performed between each of the constraint values and each of the attribute values, and any one true evaluation counts as an overall true (e.g., [1,2,3] == [6,7,2] is true). The == operator is therefore a broad interpretation of inclusion. The '===' operator requires that the constraint value and the attribute value be the same data type, length, content, and order (e.g. only [1,2,3] === [1,2,3]). The 'not' property negates the operator such that not and == means 'not equal to' (or 'not in' for a list), and not > means <=, and not < means >=, not matches means does not match, and not === means the match between the constraint and attribute values are not exact. The '==' operator SHOULD NOT be used in a manner that describes an "is a" subclass relationship for the parent QNode. |
 | value | any | **REQUIRED**. Value of the attribute. May be any data type, including a list. If the value is a list and there are multiple items, at least one comparison must be true (equivalent to OR) unless the '===' operator is used. If 'value' is of data type 'object', the keys of the object MAY be treated as a list. A 'list' data type paired with the '>' or '<' operators will encode extraneous comparisons, but this is permitted as it is in SQL and other languages. |
 | unit_id | any | CURIE of the units of the value or list of values in the 'value' property. The Units of Measurement Ontology (UO) should be used if possible. The unit_id MUST be provided for (lists of) numerical values that correspond to a quantity that has units. |
 | unit_name | any | Term name that is associated with the CURIE of the units of the value or list of values in the 'value' property. The Units of Measurement Ontology (UO) SHOULD be used if possible. This property SHOULD be provided if a unit_id is provided. This is redundant but recommended for human readability. |
 
-#### RetrievalSource [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1706:L1763)
+#### RetrievalSource [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1706:L1763)
 
 Provides information about how a particular InformationResource served as a source from which knowledge expressed in an Edge, or data used to generate this knowledge, was retrieved.
 ##### Fixed Fields
@@ -424,7 +424,7 @@ Provides information about how a particular InformationResource served as a sour
 | upstream_resource_ids | Array\[[CURIE](#curie-)\] | **Minimum items: 1.** An upstream InformationResource from which the resource being described directly retrieved a record of the knowledge expressed in the Edge, or data used to generate this knowledge. This is an array because there are cases where a merged Edge holds knowledge that was retrieved from multiple sources. e.g. an Edge provided by the ARAGORN ARA can expressing knowledge it retrieved from both the automat-mychem-info and molepro KPs, which both provided it with records of this single fact. |
 | source_record_urls | Array\[`string`\] | **Minimum items: 1.** A URL linking to a specific web page or document provided by the source, that contains a record of the knowledge expressed in the Edge. If the knowledge is contained in more than one web page on an Information Resource's site, urls MAY be provided for each. For example, Therapeutic Targets Database (TTD) has separate web pages for 'Imatinib' and its protein target KIT, both of which hold the claim that 'the KIT protein is a therapeutic target for Imatinib'. |
 
-#### ResourceRoleEnum [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/2.0/TranslatorReasonerAPI.yaml#L1764:L1775)
+#### ResourceRoleEnum [↗](https://github.com/NCATSTranslator/ReasonerAPI/blob/attribute-clarify/TranslatorReasonerAPI.yaml#L1764:L1775)
 
 The role played by the InformationResource in serving as a source for an Edge. Note that a given Edge should have one and only one 'primary' source, and may have any number of 'aggregator' or 'supporting data' sources.  This enumeration is found in Biolink Model, but is repeated here for convenience.
 `string`


### PR DESCRIPTION
Follow-up to #563. Includes update to changelog/migration/spec docs for AttributeConstraint.name now optional. And lint fix that we didn't fix in last PR.  